### PR TITLE
Fix UT issues with shops, move shop stuff to create_items instead of pre_fill

### DIFF
--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -164,6 +164,16 @@ vanilla_items_to_add: list[list[Items]] = [
 
 
 def fill_shop_items(world: "SohWorld") -> None:
+    # if we're using UT, we just want to place the event shop items in their proper spots
+    if world.using_ut:
+        world.shop_vanilla_items = world.passthrough["shop_vanilla_items"]
+        world.shop_prices = world.passthrough["shop_prices"]
+        for slot, item in world.shop_vanilla_items.items():
+            location = world.get_location(slot)
+            location.address = None
+            location.place_locked_item(world.create_item(item, create_as_event=True))
+        return
+
     if not world.options.shuffle_shops:
         no_shop_shuffle(world)
         return
@@ -179,10 +189,9 @@ def fill_shop_items(world: "SohWorld") -> None:
     for region, shop in all_shop_locations:
         vanilla_shop_slots += list(shop.keys())[0: num_vanilla]
 
-    vanilla_shop_locations = [world.get_location(
-        slot) for slot in vanilla_shop_slots]
+    vanilla_shop_locations = [world.get_location(slot) for slot in vanilla_shop_slots]
     vanilla_items = [world.create_item(item) for item in vanilla_pool]
-    world.multiworld.random.shuffle(vanilla_items)
+    world.random.shuffle(vanilla_items)
 
     # create a filled copy of the state so the multiworld can place the vanilla shop items using logic
     prefill_state = CollectionState(world.multiworld)
@@ -195,9 +204,8 @@ def fill_shop_items(world: "SohWorld") -> None:
                      vanilla_items, single_player_placement=True, lock=True)
     for slot in vanilla_shop_slots:
         location = world.get_location(slot)
-        world.get_location(slot).address = None
-        world.shop_prices[slot] = vanilla_shop_prices[Items(
-            location.item.name)]
+        location.address = None
+        world.shop_prices[slot] = vanilla_shop_prices[Items(location.item.name)]
         world.shop_vanilla_items[slot] = location.item.name
 
     min_shop_price = world.options.shuffle_shops_minimum_price.value
@@ -207,8 +215,7 @@ def fill_shop_items(world: "SohWorld") -> None:
         for slot in shop.keys():
             if slot in world.shop_prices:
                 continue
-            world.shop_prices[slot] = create_random_price(
-                min_shop_price, max_shop_price, world)
+            world.shop_prices[slot] = create_random_price(min_shop_price, max_shop_price, world)
 
 
 def no_shop_shuffle(world: "SohWorld") -> None:
@@ -247,7 +254,7 @@ def generate_merchant_prices(world: "SohWorld") -> None:
 
             world.merchant_prices[slot] = create_random_price(min_merchant_price, max_merchant_price, world)
 
-        if world.using_ut:
+        if world.using_ut and "merchant_prices" in world.passthrough:
             world.merchant_prices = world.passthrough["merchant_prices"]
 
 
@@ -263,6 +270,8 @@ def create_random_price(min_price: int, max_price: int, world: "SohWorld") -> in
 
 
 def set_price_rules(world: "SohWorld") -> None:
+    if world.options.true_no_logic:
+        return
     # Shop Price Rules
     for region, shop in all_shop_locations:
         for slot in shop.keys():

--- a/worlds/oot_soh/UniversalTracker.py
+++ b/worlds/oot_soh/UniversalTracker.py
@@ -88,6 +88,8 @@ def setup_options_from_slot_data(world: "SohWorld") -> None:
             world.options.shuffle_tycoon_wallet.value = world.passthrough.get("shuffle_tycoon_wallet", 1)
             world.options.enable_all_tricks.value = world.passthrough.get("enable_all_tricks", 0)
             world.options.tricks_in_logic.value = world.passthrough.get("tricks_in_logic", set())
+            # when adding new options to this, use .get, and set the default to whatever was before the option was made
+            # this will make it back-compatible with seeds generated on earlier versions
             # the below do not need to be handled in UT at all, since they do not affect logic
             # shuffle_100_gs_reward, ice_trap_count, ice_trap_filler_replacement, and apworld_version
         else:

--- a/worlds/oot_soh/UniversalTracker.py
+++ b/worlds/oot_soh/UniversalTracker.py
@@ -84,10 +84,10 @@ def setup_options_from_slot_data(world: "SohWorld") -> None:
             world.options.skeleton_key.value = world.passthrough["skeleton_key"]
             world.options.slingbow_break_beehives.value = world.passthrough["slingbow_break_beehives"]
             world.options.starting_age.value = world.passthrough["starting_age"]
-            world.options.true_no_logic = world.passthrough["no_logic"]
-            world.options.shuffle_tycoon_wallet = world.passthrough["shuffle_tycoon_wallet"]
-            world.options.enable_all_tricks.value = world.passthrough["enable_all_tricks"]
-            world.options.tricks_in_logic.value = world.passthrough["tricks_in_logic"]
+            world.options.true_no_logic.value = world.passthrough["no_logic"]
+            world.options.shuffle_tycoon_wallet.value = world.passthrough.get("shuffle_tycoon_wallet", 1)
+            world.options.enable_all_tricks.value = world.passthrough.get("enable_all_tricks", 0)
+            world.options.tricks_in_logic.value = world.passthrough.get("tricks_in_logic", set())
             # the below do not need to be handled in UT at all, since they do not affect logic
             # shuffle_100_gs_reward, ice_trap_count, ice_trap_filler_replacement, and apworld_version
         else:

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -163,35 +163,6 @@ class SohWorld(World):
 
         create_filler_item_pool(self)
 
-    def set_rules(self) -> None:
-        if self.options.true_no_logic:
-            return
-
-        # Completion condition.
-        self.multiworld.completion_condition[self.player] = lambda state: state.has(
-            Events.GAME_COMPLETED.value, self.player)
-
-        # UT doesn't run pre_fill, so we're doing this here instead
-        if self.using_ut:
-            self.shop_prices = self.passthrough["shop_prices"]
-            self.shop_vanilla_items = self.passthrough["shop_vanilla_items"]
-            set_price_rules(self)
-
-    def get_pre_fill_items(self) -> List["Item"]:
-        pre_fill_items = []
-
-        if self.options.shuffle_dungeon_rewards == "dungeons":
-            dungeon_reward_items = [self.create_item(
-                item.value) for item in dungeon_reward_item_mapping.values()]
-            pre_fill_items.extend(dungeon_reward_items)
-
-        for region, shop in all_shop_locations:
-            for slot, item in shop.items():
-                pre_fill_items.append(self.create_item(item))
-
-        return pre_fill_items
-
-    def pre_fill(self):
         # Prefill Dungeon Rewards. Need to collect the item pool and vanilla shop items before doing so.
         if self.options.shuffle_dungeon_rewards == "dungeons":
             # Create a filled copy of the state so the multiworld can place the dungeon rewards using logic
@@ -207,7 +178,7 @@ class SohWorld(World):
                                         for location in dungeon_reward_item_mapping.keys()]
             dungeon_reward_items = [self.create_item(
                 item.value) for item in dungeon_reward_item_mapping.values()]
-            self.multiworld.random.shuffle(dungeon_reward_items)
+            self.random.shuffle(dungeon_reward_items)
 
             # Place dungeon rewards
             fill_restrictive(self.multiworld, prefill_state, dungeon_reward_locations,
@@ -215,11 +186,15 @@ class SohWorld(World):
 
         fill_shop_items(self)
 
-        # if UT ever does start running pre_fill, this will stop it from overwriting the shop price rules
-        if self.using_ut or self.options.true_no_logic:
+        set_price_rules(self)
+
+    def set_rules(self) -> None:
+        if self.options.true_no_logic:
             return
 
-        set_price_rules(self)
+        # Completion condition.
+        self.multiworld.completion_condition[self.player] = lambda state: state.has(
+            Events.GAME_COMPLETED.value, self.player)
 
     def collect(self, state: CollectionState, item: Item) -> bool:
         changed = super().collect(state, item)


### PR DESCRIPTION
- Fixes the issue where event shop items didn't get collected properly in Universal Tracker
- Fixes some UT issues that cropped up after the tricks update
- Moves shop and dungeon item stuff to the end of create_items, since that was causing issues with both UT (since it doesn't run pre_fill) and plando early