### PR TITLE
Fix #71 (and UT)

### DIFF
--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -164,7 +164,6 @@ class Regions(StrEnum):
     GRAVEYARD_COMPOSERS_GRAVE = "Graveyard Composers Grave"
     GRAVEYARD_HEART_PIECE_GRAVE = "Graveyard Heart Piece Grave"
     GRAVEYARD_WARP_PAD_REGION = "Graveyard Warp Pad Region"
-    DEATH_MOUNTAIN = "Death Mountain"
     DEATH_MOUNTAIN_SUMMIT = "Death Mountain Summit"
     DEATH_MOUNTAIN_TRAIL = "Death Mountain Trail"
     DMT_OWL_FLIGHT = "DMT Owl Flight"

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -146,10 +146,6 @@ class SohWorld(World):
         else:
             self.vanilla_progressive_skulltula_count = progressive_skulltula_count
 
-        if self.using_ut:
-            self.vanilla_progressive_skulltula_count = self.passthrough["vanilla_progressive_skulltula_count"]
-            self.randomized_progressive_skulltula_count = self.passthrough["randomized_progressive_skulltula_count"]
-
     def create_regions(self) -> None:
         create_regions_and_locations(self)
         place_locked_items(self)

--- a/worlds/oot_soh/location_access/overworld/kakariko.py
+++ b/worlds/oot_soh/location_access/overworld/kakariko.py
@@ -25,12 +25,23 @@ def set_region_rules(world: "SohWorld") -> None:
     # Events
     add_events(Regions.KAKARIKO_VILLAGE, world, [
         (EventLocations.KAK_BUG_ROCK, Events.CAN_ACCESS_BUGS, lambda bundle: True),
-        (EventLocations.KAK_GATE, Events.KAKARIKO_GATE_OPEN,
-         lambda bundle: is_child(bundle) and has_item(Items.ZELDAS_LETTER, bundle)),
         (EventLocations.KAK_GATE_GUARD, Events.SOLD_KEATON_MASK,
          lambda bundle: is_child(bundle) and has_item(Events.CAN_BORROW_MASKS, bundle) and has_item(Items.CHILD_WALLET,
                                                                                                     bundle)),
     ])
+
+    # Open Kak Gate from the start if open gate is on, otherwise create an event in Kak for it
+    if world.options.kakariko_gate == "open":
+        add_events(Regions.ROOT, world, [
+            (EventLocations.KAK_GATE, Events.KAKARIKO_GATE_OPEN,
+             lambda bundle: True),
+        ])
+    else:
+        add_events(Regions.KAKARIKO_VILLAGE, world, [
+            (EventLocations.KAK_GATE, Events.KAKARIKO_GATE_OPEN,
+             lambda bundle: (is_child(bundle) and has_item(Items.ZELDAS_LETTER, bundle))),
+        ])
+
     # Locations
     add_locations(Regions.KAKARIKO_VILLAGE, world, [
         (Locations.SHEIK_IN_KAKARIKO,
@@ -423,7 +434,7 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.KAKARIKO_VILLAGE,
          lambda bundle: is_adult(bundle) or has_item(Events.KAKARIKO_GATE_OPEN, bundle) or can_do_trick(
              Tricks.VISIBLE_COLLISION, bundle)),
-        (Regions.DEATH_MOUNTAIN, lambda bundle: True)
+        (Regions.DEATH_MOUNTAIN_TRAIL, lambda bundle: True)
     ])
 
     # Kak Well


### PR DESCRIPTION
#71 had 2 problems: the open Kak Gate option wasn't being looked at by the logic, and the region behind Kak Gate lead to the Death Mountain region. This is the only place the logic looked at the Death Mountain region -- it's supposed to be connected to the Death Mountain Trail region.

Also there's a UT fix, just deleting something that doesn't need to be there.