### PR TITLE
Fix GC_DARUNIAS_CHAMBER_TORCH rule

### DIFF
--- a/worlds/oot_soh/location_access/overworld/goron_city.py
+++ b/worlds/oot_soh/location_access/overworld/goron_city.py
@@ -120,7 +120,7 @@ def set_region_rules(world: "SohWorld") -> None:
     # Events
     add_events(Regions.GC_DARUNIAS_CHAMBER, world, [
         (EventLocations.GC_DARUNIAS_CHAMBER_TORCH, LocalEvents.GC_CHILD_FIRE_LIT,
-         lambda bundle: is_child(bundle) or can_use(Items.STICKS, bundle))
+         lambda bundle: is_child(bundle) and can_use(Items.STICKS, bundle))
     ])
     # Locations
     add_locations(Regions.GC_DARUNIAS_CHAMBER, world, [


### PR DESCRIPTION
or -> and

This fixes the logic and makes it match upstream:
https://github.com/HarbourMasters/Shipwright/blob/e6fb9a6b64b3ee3ace61209f745ddf6b08ddecff/soh/soh/Enhancements/randomizer/location_access/overworld/goron_city.cpp#L75