### PR TITLE
Put prefill after other game's entrance rando's are done

### DIFF
--- a/worlds/oot_soh/DungeonRewardShuffle.py
+++ b/worlds/oot_soh/DungeonRewardShuffle.py
@@ -12,9 +12,26 @@ def get_pre_fill_rewards(world: "SohWorld") -> list[Items]:
         return list()
     return list(dungeon_reward_item_mapping.values())
 
+def reserve_dungeon_reward_locations(world: "SohWorld"):
+    if world.options.shuffle_dungeon_rewards != "dungeons":
+         return
+
+    for reward_location in dungeon_reward_item_mapping.keys():
+        location = world.get_location(reward_location)
+        location.place_locked_item(world.create_item(Items.RESERVATION))
+
+def remove_dungeon_reward_reservations(world: "SohWorld"):
+    for reward_location in dungeon_reward_item_mapping.keys():
+        location = world.get_location(reward_location)
+        if location.item == world.create_item(Items.RESERVATION):
+            location.item = None
+            location.locked = False
+
 def pre_fill_dungeon(world: "SohWorld") -> None:
     if world.options.shuffle_dungeon_rewards != "dungeons":
          return
+
+    remove_dungeon_reward_reservations(world)
 
     dungeon_reward_locations = [world.get_location(location.value)
                                 for location in dungeon_reward_item_mapping.keys()]

--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -988,6 +988,7 @@ class Items(StrEnum):
     STICKS = "Sticks"
     NUTS = "Nuts"
     EPONA = "Epona"
+    RESERVATION = "Prefill Reservation"
     MAX = "Max"
     # Universal Tracker Required
     GLITCHED = "Glitched Item"

--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -601,15 +601,6 @@ def create_filler_item_pool(world: "SohWorld") -> None:
 def get_open_location_count(world: "SohWorld") -> int:
     open_location_count = len(world.multiworld.get_unfilled_locations(
         world.player)) - len(world.item_pool)
-    # Subtract vanilla shop items because they're prefilled later.
-    if world.options.shuffle_shops:
-        open_location_count -= (64 -
-                                (8 * world.options.shuffle_shops_item_amount))
-    else:
-        open_location_count -= 64
-    # Subtract dungeon rewards when set to dungeons as they're prefilled later.
-    if world.options.shuffle_dungeon_rewards == "dungeons":
-        open_location_count -= 9
 
     if world.options.boss_key_shuffle in ("own_dungeon", "any_dungeon", "overworld"):
         open_location_count -= 5
@@ -663,10 +654,6 @@ def get_open_location_count(world: "SohWorld") -> int:
 
     if world.options.maps_and_compasses in ("own_dungeon", "any_dungeon", "overworld"):
         open_location_count -= len(map_and_compass_vanilla_mapping)
-
-    if world.options.shuffle_songs in ("song_locations", "dungeon_rewards"):
-        for _ in song_vanilla_locations.values():
-            open_location_count -= 1
 
     return open_location_count
 

--- a/worlds/oot_soh/Items.py
+++ b/worlds/oot_soh/Items.py
@@ -312,6 +312,7 @@ item_data_table: dict[Items, SohItemData] = {
     Items.STICKS: SohItemData(None, child_only=True),
     Items.NUTS: SohItemData(None),
     Items.EPONA: SohItemData(None),
+    Items.RESERVATION: SohItemData(None),
     # Items.MAX: SohItemData( 279, IC.filler, 0 ),
     # Intentionally place the glitched item without a value. Everything else should be above this.
     Items.GLITCHED: SohItemData(None),

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -189,6 +189,9 @@ wallet_capacities: dict[Items, int] = {
     Items.TYCOON_WALLET: 999
 }
 
+def can_afford_slot(slot: str, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
+    slot_price = bundle[2].shop_prices[slot]
+    return can_afford(slot_price, bundle)
 
 def can_afford(price: int, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     for wallet, amount in wallet_capacities.items():

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -71,6 +71,7 @@ from .location_access.dungeons import \
     spirit_temple, \
     water_temple
 from .SongShuffle import song_vanilla_locations
+from .ShopItems import no_shop_shuffle
 
 if TYPE_CHECKING:
     from . import SohWorld
@@ -456,6 +457,9 @@ def place_locked_items(world: "SohWorld") -> None:
         world.get_location(Locations.GANONS_CASTLE_TOWER_BOSS_KEY_CHEST).place_locked_item(
             world.create_item(Items.GANONS_CASTLE_BOSS_KEY))
 
+    # Place vanilla shop items if they're not shuffled
+    if not world.options.shuffle_shops:
+        no_shop_shuffle(world)
 
     token_item_progressive = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True, ItemClassification.progression_deprioritized_skip_balancing)
     token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)

--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 from worlds.generic.Rules import add_rule
 from Fill import fill_restrictive
 
-from .LogicHelpers import rule_wrapper, can_afford
+from .LogicHelpers import rule_wrapper, can_afford, can_afford_slot
 from .Locations import scrubs_location_table, merchants_items_location_table, scrubs_one_time_only
 from .Enums import *
 from . import SohItem
@@ -321,10 +321,9 @@ def set_price_rules(world: "SohWorld") -> None:
     # Shop Price Rules
     for region, shop in all_shop_locations:
         for slot in shop.keys():
-            price = world.shop_prices[slot]
-            def price_rule(bundle, p=price): return can_afford(p, bundle)
+            def shop_rule(bundle, s=slot): return can_afford_slot(str(s), bundle)
             location = world.get_location(slot)
-            add_rule(location, rule_wrapper.wrap(region, price_rule, world))
+            add_rule(location, rule_wrapper.wrap(region, shop_rule, world))
 
     # Scrub Price Rules
     if world.options.shuffle_scrubs:

--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -191,6 +191,8 @@ def get_vanilla_shop_locations(world: "SohWorld") -> list[str]:
 
 
 def reserve_vanilla_shop_locations(world: "SohWorld") -> None:
+    if not world.options.shuffle_shops:
+        return
     vanilla_shop_slots = get_vanilla_shop_locations(world)
     for slot in vanilla_shop_slots:
         location = world.get_location(slot)
@@ -205,7 +207,6 @@ def remove_vanilla_shop_reservations(world: "SohWorld") -> None:
             location.locked = False
 
 def fill_shop_items(world: "SohWorld") -> None:
-    remove_vanilla_shop_reservations(world)
     # if we're using UT, we just want to place the event shop items in their proper spots
     if world.using_ut:
         world.shop_vanilla_items = world.passthrough["shop_vanilla_items"]
@@ -219,6 +220,8 @@ def fill_shop_items(world: "SohWorld") -> None:
     if not world.options.shuffle_shops:
         return
 
+    remove_vanilla_shop_reservations(world)
+    
     # select what shop slots to and vanilla items to shuffle
     num_vanilla = 8 - world.options.shuffle_shops_item_amount
     vanilla_pool = get_vanilla_shop_pool(world)

--- a/worlds/oot_soh/SongShuffle.py
+++ b/worlds/oot_soh/SongShuffle.py
@@ -25,6 +25,21 @@ song_vanilla_locations: dict[Locations, Items] = {
     Locations.SHEIK_AT_TEMPLE: Items.PRELUDE_OF_LIGHT
 }
 
+dungeon_reward_locations: list[Locations] = [
+    Locations.DEKU_TREE_QUEEN_GOHMA_HEART_CONTAINER,
+    Locations.DODONGOS_CAVERN_KING_DODONGO_HEART_CONTAINER,
+    Locations.JABU_JABUS_BELLY_BARINADE_HEART_CONTAINER,
+    Locations.FOREST_TEMPLE_PHANTOM_GANON_HEART_CONTAINER,
+    Locations.FIRE_TEMPLE_VOLVAGIA_HEART_CONTAINER,
+    Locations.WATER_TEMPLE_MORPHA_HEART_CONTAINER,
+    Locations.SHADOW_TEMPLE_BONGO_BONGO_HEART_CONTAINER,
+    Locations.SPIRIT_TEMPLE_TWINROVA_HEART_CONTAINER,
+    Locations.SONG_FROM_IMPA,
+    Locations.SHEIK_IN_ICE_CAVERN,
+    Locations.BOTTOM_OF_THE_WELL_LENS_OF_TRUTH_CHEST,   # todo MQ lens of truth chest
+    Locations.GERUDO_TRAINING_GROUND_MAZE_PATH_FINAL_CHEST # todo MQ ice arrow chest
+]
+
 def get_prefill_songs(world: "SohWorld") -> list[Items]:
     # Do not prefill songs anywhere in particular
     if world.options.shuffle_songs in ("off", "anywhere"):
@@ -32,10 +47,37 @@ def get_prefill_songs(world: "SohWorld") -> list[Items]:
     
     return list(song_vanilla_locations.values())
 
+def reserve_song_locations(world: "SohWorld") -> None:
+    if world.options.shuffle_songs in ("off", "anywhere"):
+        return
+    
+    reservation_locations = list[Locations]()
+
+    if world.options.shuffle_songs == "song_locations":
+        reservation_locations = list(song_vanilla_locations.keys())
+    if world.options.shuffle_songs == "dungeon_rewards":
+        reservation_locations = dungeon_reward_locations
+
+    for song_location in reservation_locations:
+        location = world.get_location(song_location)
+        location.place_locked_item(world.create_item(Items.RESERVATION))
+
+def remove_song_reservations(world: "SohWorld") -> None:
+    reservation_locations = list(song_vanilla_locations.keys())
+    reservation_locations += dungeon_reward_locations
+
+    for song_location in reservation_locations:
+        location = world.get_location(song_location)
+        if location.item == world.create_item(Items.RESERVATION):
+            location.item = None
+            location.locked = False
+
 def pre_fill_songs(world: "SohWorld") -> None:
     # Do not prefill songs anywhere in particular
     if world.options.shuffle_songs in ("off", "anywhere"):
         return
+    
+    remove_song_reservations(world)
 
     songs = list[SohItem]()
     for item in get_prefill_songs(world):
@@ -53,20 +95,7 @@ def pre_fill_songs(world: "SohWorld") -> None:
         return
 
     if world.options.shuffle_songs == "dungeon_rewards":
-        reward_locations = list()
-        reward_locations.append(world.get_location(Locations.DEKU_TREE_QUEEN_GOHMA_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.DODONGOS_CAVERN_KING_DODONGO_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.JABU_JABUS_BELLY_BARINADE_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.FOREST_TEMPLE_PHANTOM_GANON_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.FIRE_TEMPLE_VOLVAGIA_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.WATER_TEMPLE_MORPHA_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.SHADOW_TEMPLE_BONGO_BONGO_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.SPIRIT_TEMPLE_TWINROVA_HEART_CONTAINER))
-        reward_locations.append(world.get_location(Locations.SONG_FROM_IMPA))
-        reward_locations.append(world.get_location(Locations.SHEIK_IN_ICE_CAVERN))
-        reward_locations.append(world.get_location(Locations.BOTTOM_OF_THE_WELL_LENS_OF_TRUTH_CHEST))   # todo MQ lens of truth chest
-        reward_locations.append(world.get_location(Locations.GERUDO_TRAINING_GROUND_MAZE_PATH_FINAL_CHEST)) # todo MQ ice arrow chest
-
+        reward_locations = [world.get_location(loc) for loc in dungeon_reward_locations]
         fill_restrictive(world.multiworld, prefill_state, reward_locations, songs, single_player_placement=True, lock=True)
         return
     

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -255,7 +255,7 @@ class SohWorld(World):
         prefill_state.sweep_for_advancements()
         return prefill_state
     
-    def create_rules(self) -> None:
+    def set_rules(self) -> None:
         # Set price rules in advance
         generate_shop_prices(self)
         generate_scrub_prices(self)


### PR DESCRIPTION
Prefilling our items before connect entrances causes issues with games that enable entrance randomization.

This PR puts prefill back into the prefill step.
To avoid plando putting items in shops prices for shops are now set during the set_rules step
And locations that will get prefilled for sure get locked with a reservation item where appropriate.
ensuring plando doesn't put 'early_locations' and 'non_early_locations' there.

the dungeon shuffle locations are exempted from reservation for now because the pool of possible locations is so vast it would need some more thought put into what gets reserved.

because shop, song and reward locations get reserved now, these locations aren't empty anymore during item pool generation so don't need to be accounted for when creating filler items