### PR TITLE
Version bump 1.2.0

### DIFF
--- a/worlds/oot_soh/archipelago.json
+++ b/worlds/oot_soh/archipelago.json
@@ -1,6 +1,6 @@
 {
     "game": "Ship of Harkinian",
     "authors": ["aMannus", "jeromkiller", "ScipioWright", "Fanta-Tanked", "Sam", "DaComputerNerd717", "A-Green-Spoon", "StuBob", "Tzuf23", "mattman107", "Varuuna", "Lorithan", "BootsinSoots", "briaguya", "Sirius902", "ThatHypedPerson"],
-    "world_version": "1.1.0",
+    "world_version": "1.2.0",
     "minimum_ap_version": "0.6.3"
 }


### PR DESCRIPTION
Sadly a 1.x update is needed to add better version handling in the client itself (done here: https://github.com/jeromkiller/Shipwright_archipellago/pull/10)

Only merge after the prefill PR so we can send the apworld only fix to people that want it.