### PR TITLE
Fixed Unit tests

### DIFF
--- a/worlds/oot_soh/test/test_collect_remove.py
+++ b/worlds/oot_soh/test/test_collect_remove.py
@@ -5,7 +5,7 @@ from .bases import SohTestBase
 
 class TestCollectRemoveAllOff(SohTestBase):
     options = {"shuffle_childs_wallet": False, "shuffle_swim": False, "shuffle_deku_stick_bag": False,
-               "shuffle_deku_nut_bag": False, "bombchu_bag": False}
+               "shuffle_deku_nut_bag": False, "bombchu_bag": "none", "shuffle_ocarinas": True}
     world: SohWorld
     optional_prog_item_set = {Items.PROGRESSIVE_SCALE, Items.PROGRESSIVE_WALLET, Items.PROGRESSIVE_STICK_CAPACITY,
                               Items.PROGRESSIVE_NUT_CAPACITY, Items.BOMBCHU_BAG}
@@ -71,7 +71,7 @@ class TestCollectRemoveAllOff(SohTestBase):
 
 class TestCollectRemoveAllOn(SohTestBase):
     options = {"shuffle_childs_wallet": True, "shuffle_swim": True, "shuffle_deku_stick_bag": True,
-               "shuffle_deku_nut_bag": True, "bombchu_bag": True}
+               "shuffle_deku_nut_bag": True, "bombchu_bag": "single_bag", "shuffle_ocarinas": True}
     world: SohWorld
 
     def test_single_of_each(self):

--- a/worlds/oot_soh/test/test_deku_tree_access.py
+++ b/worlds/oot_soh/test/test_deku_tree_access.py
@@ -4,7 +4,7 @@ from ..Items import Items
 from .bases import SohTestBase
 
 class TestDekuTreeUpperBasement(SohTestBase):
-    options = {"starting_age": 0, "closed_forest": 2, "door_of_time": 0}
+    options = {"starting_age": 0, "closed_forest": 2, "door_of_time": 0, "shuffle_kokiri_sword": 1}
     world: SohWorld
 
     def test_child_without_slingshot_upper_basement_access(self):

--- a/worlds/oot_soh/test/test_time.py
+++ b/worlds/oot_soh/test/test_time.py
@@ -3,7 +3,7 @@ from ..Enums import Items, Locations
 
 
 class TestTime(SohTestBase):
-    options = {"starting_age": "adult", "shuffle_grass": "all"}
+    options = {"starting_age": "adult", "shuffle_grass": "all", "shuffle_kokiri_sword": 1}
 
     # test that you cannot cut the market grass if you do not have a grass cutter for child Link
     def test_wrong_age_grass(self):


### PR DESCRIPTION
Unit tests got broken because certain items weren't shuffled into the pool anymore by default,
the bombchu settings also got changed which required an update to the tests too