### PR TITLE
Rename Bobmbchu bag item group

### DIFF
--- a/worlds/oot_soh/Items.py
+++ b/worlds/oot_soh/Items.py
@@ -77,7 +77,7 @@ item_data_table: dict[Items, SohItemData] = {
     Items.PROGRESSIVE_SCALE: SohItemData(45, IC.progression | IC.useful, 2, item_groups=["Bronze Scale", "Silver Scale", "Golden Scale", "Scale"]),
     Items.PROGRESSIVE_NUT_CAPACITY: SohItemData(46, IC.progression | IC.useful, 2, item_groups=["Deku Nut Bag"]),
     Items.PROGRESSIVE_STICK_CAPACITY: SohItemData(47, IC.progression | IC.useful, 2, item_groups=["Stick Bag"]),
-    Items.BOMBCHU_BAG: SohItemData(48, IC.progression | IC.useful, 0, item_groups=["Bombchu Bag", "Bombs"]),
+    Items.BOMBCHU_BAG: SohItemData(48, IC.progression | IC.useful, 0, item_groups=["Progressive Bombchu Bag", "Bombs"]),
     Items.PROGRESSIVE_MAGIC_METER: SohItemData(49, IC.progression | IC.useful, 2, item_groups=["Magic Meter"]),
     # Items.MAGIC_SINGLE: SohItemData( 50, IC.filler, 0 ),
     # Items.MAGIC_DOUBLE: SohItemData( 51, IC.filler, 0 ),


### PR DESCRIPTION
After bombchu bag got refactored the item and group it's in are both the same name. This commit changes the item group name to the old name, so players can still use that for hints or something