### PR TITLE
Split key prefill into multiple stages to fix prefill issues

### DIFF
--- a/worlds/oot_soh/DungeonRewardShuffle.py
+++ b/worlds/oot_soh/DungeonRewardShuffle.py
@@ -27,7 +27,7 @@ def remove_dungeon_reward_reservations(world: "SohWorld"):
             location.item = None
             location.locked = False
 
-def pre_fill_dungeon(world: "SohWorld") -> None:
+def pre_fill_dungeon_rewards(world: "SohWorld") -> None:
     if world.options.shuffle_dungeon_rewards != "dungeons":
          return
 

--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -3867,5 +3867,3 @@ class KeyShuffleLocations(Enum):
     BOTTOM_OF_THE_WELL = auto()
     GERUDO_TRAINING_GROUNDS = auto()
     GANONS_CASTLE = auto()
-    ANY_DUNGEON = auto()
-    OVERWORLD = auto()

--- a/worlds/oot_soh/KeyShuffle.py
+++ b/worlds/oot_soh/KeyShuffle.py
@@ -7,6 +7,7 @@ from .Locations import Location, location_data_table
 from .Regions import dungeon_reward_item_mapping, map_and_compass_vanilla_mapping
 from .Enums import KeyShuffleLocations, Locations
 from .ShopItems import get_vanilla_shop_locations
+from .SongShuffle import dungeon_reward_song_locations
 from .LogicHelpers import key_to_ring
 
 if TYPE_CHECKING:
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 
 option_mapping = namedtuple('Key_Mapping', ['Dungeon', 'Option', 'Quantity'])
 
-def get_pre_fill_keys(world: "SohWorld") -> dict[KeyShuffleLocations, list[Items]]:
+def get_own_dungeon_prefill_items(world: "SohWorld") -> dict[KeyShuffleLocations, list[Items]]:
         key_shuffle_locations = dict[KeyShuffleLocations, list[Items]]()
         for location_type in KeyShuffleLocations:
             key_shuffle_locations[location_type] = list[Items]()
@@ -26,15 +27,11 @@ def get_pre_fill_keys(world: "SohWorld") -> dict[KeyShuffleLocations, list[Items
             key_shuffle_locations[KeyShuffleLocations.WATER_TEMPLE].append(Items.WATER_TEMPLE_BOSS_KEY)
             key_shuffle_locations[KeyShuffleLocations.SPIRIT_TEMPLE].append(Items.SPIRIT_TEMPLE_BOSS_KEY)
             key_shuffle_locations[KeyShuffleLocations.SHADOW_TEMPLE].append(Items.SHADOW_TEMPLE_BOSS_KEY)
-        elif world.options.boss_key_shuffle == "any_dungeon":
-            key_shuffle_locations[KeyShuffleLocations.ANY_DUNGEON] += [Items.FOREST_TEMPLE_BOSS_KEY, Items.FIRE_TEMPLE_BOSS_KEY, Items.WATER_TEMPLE_BOSS_KEY, Items.SPIRIT_TEMPLE_BOSS_KEY, Items.SHADOW_TEMPLE_BOSS_KEY]
-        elif world.options.boss_key_shuffle == "overworld":
-            key_shuffle_locations[KeyShuffleLocations.OVERWORLD] += [Items.FOREST_TEMPLE_BOSS_KEY, Items.FIRE_TEMPLE_BOSS_KEY, Items.WATER_TEMPLE_BOSS_KEY, Items.SPIRIT_TEMPLE_BOSS_KEY, Items.SHADOW_TEMPLE_BOSS_KEY]
 
         # Small Keys
         small_key_option_mapping = small_key_option_matching(world)
         
-        if world.options.small_key_shuffle in ("own_dungeon", "any_dungeon", "overworld"):
+        if world.options.small_key_shuffle == "own_dungeon":
             # Put the small keys or keyrings in the appropriate pool
             for key, data in small_key_option_mapping.items():
                 dungeon = data.Dungeon
@@ -47,31 +44,8 @@ def get_pre_fill_keys(world: "SohWorld") -> dict[KeyShuffleLocations, list[Items
                     item = key
                     count = data.Quantity
 
-                if world.options.small_key_shuffle == "own_dungeon":
-                    for _ in range(count):
-                        key_shuffle_locations[dungeon].append(item)
-                elif world.options.small_key_shuffle == "any_dungeon":
-                    for _ in range(count):
-                        key_shuffle_locations[KeyShuffleLocations.ANY_DUNGEON].append(item)
-                elif world.options.small_key_shuffle == "overworld":
-                    for _ in range(count):
-                        key_shuffle_locations[KeyShuffleLocations.OVERWORLD].append(item)
-
-        # Gerudo Fortress Keys
-        if world.options.fortress_carpenters != "free":
-            if world.options.gerudo_fortress_key_shuffle == "any_dungeon":
-                if world.options.gerudo_fortress_key_ring and world.options.fortress_carpenters == "normal" and world.options.gerudo_fortress_key_shuffle != "vanilla":
-                    key_shuffle_locations[KeyShuffleLocations.ANY_DUNGEON].append(Items.GERUDO_FORTRESS_KEY_RING)
-                else:
-                    for _ in range(item_data_table[Items.GERUDO_FORTRESS_SMALL_KEY].quantity_in_item_pool if world.options.fortress_carpenters == "normal" else 1):
-                        key_shuffle_locations[KeyShuffleLocations.ANY_DUNGEON].append(Items.GERUDO_FORTRESS_SMALL_KEY)
-
-            elif world.options.gerudo_fortress_key_shuffle == "overworld":
-                if world.options.gerudo_fortress_key_ring and world.options.fortress_carpenters == "normal" and world.options.gerudo_fortress_key_shuffle != "vanilla":
-                    key_shuffle_locations[KeyShuffleLocations.OVERWORLD].append(Items.GERUDO_FORTRESS_KEY_RING)
-                else:
-                    for _ in range(item_data_table[Items.GERUDO_FORTRESS_SMALL_KEY].quantity_in_item_pool if world.options.fortress_carpenters == "normal" else 1):
-                        key_shuffle_locations[KeyShuffleLocations.OVERWORLD].append(Items.GERUDO_FORTRESS_SMALL_KEY)
+                for _ in range(count):
+                    key_shuffle_locations[dungeon].append(item)
 
         # Maps and Compasses
         if world.options.maps_and_compasses == "own_dungeon":
@@ -90,50 +64,121 @@ def get_pre_fill_keys(world: "SohWorld") -> dict[KeyShuffleLocations, list[Items
 
             for shuffle_location, items in map_and_compass_dungeon_mapping.items():
                 key_shuffle_locations[shuffle_location] += items
-        elif world.options.maps_and_compasses == "any_dungeon":
-            key_shuffle_locations[KeyShuffleLocations.ANY_DUNGEON] += list(map_and_compass_vanilla_mapping.values())
-        elif world.options.maps_and_compasses == "overworld":
-            key_shuffle_locations[KeyShuffleLocations.OVERWORLD] += list(map_and_compass_vanilla_mapping.values())
 
         return key_shuffle_locations
 
-    
+def get_any_dungeon_prefill_items(world: "SohWorld") -> list[Items]:
+        any_dungeon_items = list[Items]()
 
-def pre_fill_keys(world: "SohWorld") -> None:
+        # Boss Keys
+        if world.options.boss_key_shuffle == "any_dungeon":
+            any_dungeon_items += [Items.FOREST_TEMPLE_BOSS_KEY, Items.FIRE_TEMPLE_BOSS_KEY, Items.WATER_TEMPLE_BOSS_KEY, Items.SPIRIT_TEMPLE_BOSS_KEY, Items.SHADOW_TEMPLE_BOSS_KEY]
+
+        # Small Keys
+        small_key_option_mapping = small_key_option_matching(world)
+        
+        if world.options.small_key_shuffle == "any_dungeon":
+            # Put the small keys or keyrings in the appropriate pool
+            for key, data in small_key_option_mapping.items():
+                key_ring_option = data.Option
+
+                if key_ring_option:
+                    item = key_to_ring[key]
+                    count = 1
+                else:
+                    item = key
+                    count = data.Quantity
+
+                for _ in range(count):
+                    any_dungeon_items.append(item)
+
+        # Gerudo Fortress Keys
+        if world.options.fortress_carpenters != "free":
+            if world.options.gerudo_fortress_key_shuffle == "any_dungeon":
+                if world.options.gerudo_fortress_key_ring and world.options.fortress_carpenters == "normal" and world.options.gerudo_fortress_key_shuffle != "vanilla":
+                    any_dungeon_items.append(Items.GERUDO_FORTRESS_KEY_RING)
+                else:
+                    for _ in range(item_data_table[Items.GERUDO_FORTRESS_SMALL_KEY].quantity_in_item_pool if world.options.fortress_carpenters == "normal" else 1):
+                        any_dungeon_items.append(Items.GERUDO_FORTRESS_SMALL_KEY)
+
+        # Maps and Compasses
+        if world.options.maps_and_compasses == "any_dungeon":
+            any_dungeon_items += list(map_and_compass_vanilla_mapping.values())
+
+        return any_dungeon_items
+        
+def get_overworld_prefill_items(world: "SohWorld") -> list[Items]:
+        overworld_items = list[Items]()
+
+        # Boss Keys
+        if world.options.boss_key_shuffle == "overworld":
+            overworld_items += [Items.FOREST_TEMPLE_BOSS_KEY, Items.FIRE_TEMPLE_BOSS_KEY, Items.WATER_TEMPLE_BOSS_KEY, Items.SPIRIT_TEMPLE_BOSS_KEY, Items.SHADOW_TEMPLE_BOSS_KEY]
+
+        # Small Keys
+        small_key_option_mapping = small_key_option_matching(world)
+        
+        if world.options.small_key_shuffle == "overworld":
+            # Put the small keys or keyrings in the appropriate pool
+            for key, data in small_key_option_mapping.items():
+                key_ring_option = data.Option
+
+                if key_ring_option:
+                    item = key_to_ring[key]
+                    count = 1
+                else:
+                    item = key
+                    count = data.Quantity
+
+                for _ in range(count):
+                    overworld_items.append(item)
+
+        # Gerudo Fortress Keys
+        if world.options.fortress_carpenters != "free":
+            if world.options.gerudo_fortress_key_shuffle == "overworld":
+                if world.options.gerudo_fortress_key_ring and world.options.fortress_carpenters == "normal" and world.options.gerudo_fortress_key_shuffle != "vanilla":
+                    overworld_items.append(Items.GERUDO_FORTRESS_KEY_RING)
+                else:
+                    for _ in range(item_data_table[Items.GERUDO_FORTRESS_SMALL_KEY].quantity_in_item_pool if world.options.fortress_carpenters == "normal" else 1):
+                        overworld_items.append(Items.GERUDO_FORTRESS_SMALL_KEY)
+
+        # Maps and Compasses
+        if world.options.maps_and_compasses == "overworld":
+            overworld_items += list(map_and_compass_vanilla_mapping.values())
+
+        return overworld_items
+
+def pre_fill_own_dungeon_items(world: "SohWorld") -> None:
         all_locations: list[str] = [location.name for location in world.multiworld.get_unfilled_locations(world.player)]
         reserved_locations: list[Locations] = []
 
         # Reserve dungeon reward locations if a dungeon reward should be there
         if world.options.shuffle_dungeon_rewards != "anywhere":
-            reserved_locations += [location for location in dungeon_reward_item_mapping.keys()]
+            reserved_locations += list(dungeon_reward_item_mapping.keys())
 
-        # Reserve Shop Locations
-        for shop_loc in get_vanilla_shop_locations(world):
-            reserved_locations.append(Locations(shop_loc))
+        if world.options.shuffle_songs == "dungeon_rewards":
+            reserved_locations += dungeon_reward_song_locations
 
-        key_shuffle_keys = get_pre_fill_keys(world)
+        key_shuffle_keys = get_own_dungeon_prefill_items(world)
         key_shuffle_locations = dict[KeyShuffleLocations, list[Locations]]()
         for location_type in KeyShuffleLocations:
-            key_shuffle_locations[location_type] = list[Location]()
+            key_shuffle_locations[location_type] = list[Locations]()
 
         # This loops through all unfilled locations in the players world, removes any from our reserved list (Shops and Dungeon Rewards if applicable), then sorts them into three categories: Overworld, Any Dungeon, and Own Dungeon
         for name, data in location_data_table.items():
             if name in all_locations and name not in reserved_locations:
-                if data.key_suffle_location == None:
-                    key_shuffle_locations[KeyShuffleLocations.OVERWORLD].append(Locations(name))
-                else:
-                    key_shuffle_locations[KeyShuffleLocations.ANY_DUNGEON].append(Locations(name))
+                if data.key_suffle_location != None:
                     key_shuffle_locations[data.key_suffle_location].append(Locations(name))
 
-        # use full dungeon accessability as the goal for filling
-        all_dungeon_location_goal = [world.get_location(loc) for loc in key_shuffle_locations[KeyShuffleLocations.ANY_DUNGEON]]
-        world.multiworld.completion_condition[world.player] = lambda state: all([state.can_reach(loc) for loc in all_dungeon_location_goal])
-
-        # Resolve own_dungeon, any_dungeon and overworld options
+        # Resolve own_dungeon
         for shuffle_location, keys in key_shuffle_keys.items():
             if not keys:
                 continue
 
+            # use full dungeon accessability as the goal for filling
+            own_dungeon_location_goal = [world.get_location(loc) for loc in key_shuffle_locations[shuffle_location]]
+            world.multiworld.completion_condition[world.player] = lambda state: all([state.can_reach(loc) for loc in own_dungeon_location_goal])
+
+            # remove items from the prefill pool
             for key in keys:
                 if key in world.pre_fill_pool: 
                     world.pre_fill_pool.remove(key)
@@ -152,9 +197,80 @@ def pre_fill_keys(world: "SohWorld") -> None:
             empty_locations = world.get_empty_locations_from_list_shuffled(key_shuffle_locations[shuffle_location])
             key_items = [world.create_item(str(key)) for key in keys]
 
-            fill_restrictive(world.multiworld, prefill_state, empty_locations, key_items, single_player_placement=True, lock=True)
+            fill_restrictive(world.multiworld, prefill_state, empty_locations, key_items, single_player_placement=True, lock=True) 
 
-def small_key_option_matching(world: "SohWorld") -> dict[Items: option_mapping]:
+def pre_fill_any_dungeon_keys(world: "SohWorld") -> None:
+        all_locations: list[str] = [location.name for location in world.multiworld.get_unfilled_locations(world.player)]
+        reserved_locations: list[Locations] = []
+
+        # Reserve dungeon reward locations if a dungeon reward should be there
+        if world.options.shuffle_dungeon_rewards != "anywhere":
+            reserved_locations += [location for location in dungeon_reward_item_mapping.keys()]
+
+        if world.options.shuffle_songs == "dungeon_rewards":
+            reserved_locations += dungeon_reward_song_locations
+
+        any_dungeon_items = get_any_dungeon_prefill_items(world)
+        any_dungeon_locations = list[Locations]()
+
+        # This loops through all unfilled locations in the players world, removes any from our reserved list (Shops and Dungeon Rewards if applicable), then sorts them into three categories: Overworld, Any Dungeon, and Own Dungeon
+        for name, data in location_data_table.items():
+            if name in all_locations and name not in reserved_locations:
+                if data.key_suffle_location != None:
+                    any_dungeon_locations.append(Locations(name))
+
+        # use full dungeon accessability as the goal for filling
+        all_dungeon_location_goal = [world.get_location(loc) for loc in any_dungeon_locations]
+        world.multiworld.completion_condition[world.player] = lambda state: all([state.can_reach(loc) for loc in all_dungeon_location_goal])
+
+        # Resolve any_dungeon
+        for item in any_dungeon_items:
+            if item in world.pre_fill_pool: 
+                world.pre_fill_pool.remove(item)
+
+        prefill_state = world.get_pre_fill_state()
+        prefill_state.sweep_for_advancements()
+
+        empty_locations = world.get_empty_locations_from_list_shuffled(any_dungeon_locations)
+        key_items = [world.create_item(str(item)) for item in any_dungeon_items]
+
+        fill_restrictive(world.multiworld, prefill_state, empty_locations, key_items, single_player_placement=True, lock=True)
+
+def pre_fill_overworld_items(world: "SohWorld") -> None:
+        all_locations: list[str] = [location.name for location in world.multiworld.get_unfilled_locations(world.player)]
+        reserved_locations: list[Locations] = []
+
+        # Reserve Shop Locations
+        for shop_loc in get_vanilla_shop_locations(world):
+            reserved_locations.append(Locations(shop_loc))
+
+        overworld_items = get_overworld_prefill_items(world)
+        overworld_locations = list[Locations]()
+
+        # This loops through all unfilled locations in the players world, removes any from our reserved list (Shops and Dungeon Rewards if applicable), then sorts them into three categories: Overworld, Any Dungeon, and Own Dungeon
+        for name, data in location_data_table.items():
+            if name in all_locations and name not in reserved_locations:
+                if data.key_suffle_location == None:
+                    overworld_locations.append(Locations(name))
+
+        # use full dungeon accessability as the goal for filling
+        all_dungeon_location_goal = [world.get_location(loc) for loc in overworld_locations]
+        world.multiworld.completion_condition[world.player] = lambda state: all([state.can_reach(loc) for loc in all_dungeon_location_goal])
+
+        # Resolve overworld
+        for item in overworld_items:
+            if item in world.pre_fill_pool: 
+                world.pre_fill_pool.remove(item)
+
+        prefill_state = world.get_pre_fill_state()
+        prefill_state.sweep_for_advancements()
+
+        empty_locations = world.get_empty_locations_from_list_shuffled(overworld_locations)
+        key_items = [world.create_item(str(item)) for item in overworld_items]
+
+        fill_restrictive(world.multiworld, prefill_state, empty_locations, key_items, single_player_placement=True, lock=True)
+
+def small_key_option_matching(world: "SohWorld") -> dict[Items, option_mapping]:
     return {
             Items.FOREST_TEMPLE_SMALL_KEY: option_mapping(KeyShuffleLocations.FOREST_TEMPLE, world.options.forest_temple_key_ring, item_data_table[Items.FOREST_TEMPLE_SMALL_KEY].quantity_in_item_pool),
             Items.FIRE_TEMPLE_SMALL_KEY: option_mapping(KeyShuffleLocations.FIRE_TEMPLE, world.options.fire_temple_key_ring, item_data_table[Items.FIRE_TEMPLE_SMALL_KEY].quantity_in_item_pool),

--- a/worlds/oot_soh/SongShuffle.py
+++ b/worlds/oot_soh/SongShuffle.py
@@ -25,7 +25,7 @@ song_vanilla_locations: dict[Locations, Items] = {
     Locations.SHEIK_AT_TEMPLE: Items.PRELUDE_OF_LIGHT
 }
 
-dungeon_reward_locations: list[Locations] = [
+dungeon_reward_song_locations: list[Locations] = [
     Locations.DEKU_TREE_QUEEN_GOHMA_HEART_CONTAINER,
     Locations.DODONGOS_CAVERN_KING_DODONGO_HEART_CONTAINER,
     Locations.JABU_JABUS_BELLY_BARINADE_HEART_CONTAINER,
@@ -56,7 +56,7 @@ def reserve_song_locations(world: "SohWorld") -> None:
     if world.options.shuffle_songs == "song_locations":
         reservation_locations = list(song_vanilla_locations.keys())
     if world.options.shuffle_songs == "dungeon_rewards":
-        reservation_locations = dungeon_reward_locations
+        reservation_locations = dungeon_reward_song_locations
 
     for song_location in reservation_locations:
         location = world.get_location(song_location)
@@ -64,7 +64,7 @@ def reserve_song_locations(world: "SohWorld") -> None:
 
 def remove_song_reservations(world: "SohWorld") -> None:
     reservation_locations = list(song_vanilla_locations.keys())
-    reservation_locations += dungeon_reward_locations
+    reservation_locations += dungeon_reward_song_locations
 
     for song_location in reservation_locations:
         location = world.get_location(song_location)
@@ -89,12 +89,12 @@ def pre_fill_songs(world: "SohWorld") -> None:
     world.multiworld.completion_condition[world.player] = lambda state: all([state.can_reach(loc) for loc in reward_goal_locations])
 
     if world.options.shuffle_songs == "song_locations":
-        song_locations = world.get_empty_locations_from_list_shuffled(song_vanilla_locations.keys())
+        song_locations = world.get_empty_locations_from_list_shuffled(list(song_vanilla_locations.keys()))
         fill_restrictive(world.multiworld, prefill_state, song_locations, songs, single_player_placement=True, lock=True)
         return
 
     if world.options.shuffle_songs == "dungeon_rewards":
-        reward_locations = world.get_empty_locations_from_list_shuffled(dungeon_reward_locations)
+        reward_locations = world.get_empty_locations_from_list_shuffled(dungeon_reward_song_locations)
         fill_restrictive(world.multiworld, prefill_state, reward_locations, songs, single_player_placement=True, lock=True)
         return
     

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -13,8 +13,8 @@ from .Regions import create_regions_and_locations, place_locked_items
 from .Enums import *
 from .ItemPool import create_item_pool, create_filler_item_pool, create_triforce_pieces, get_filler_item
 from . import RegionAgeAccess
-from .DungeonRewardShuffle import pre_fill_dungeon, get_pre_fill_rewards
-from .KeyShuffle import pre_fill_keys, get_pre_fill_keys
+from .DungeonRewardShuffle import pre_fill_dungeon_rewards, get_pre_fill_rewards
+from .KeyShuffle import pre_fill_own_dungeon_items, pre_fill_any_dungeon_keys, pre_fill_overworld_items, get_own_dungeon_prefill_items, get_any_dungeon_prefill_items, get_overworld_prefill_items
 from .SongShuffle import pre_fill_songs, get_prefill_songs
 from .ShopItems import fill_shop_items, generate_shop_prices, generate_scrub_prices, generate_merchant_prices, set_price_rules
 from .Presets import oot_soh_options_presets
@@ -181,8 +181,10 @@ class SohWorld(World):
         # generate the prefill pool
         self.pre_fill_pool += get_pre_fill_rewards(self)
         self.pre_fill_pool += get_prefill_songs(self)
-        for key_shuffle in get_pre_fill_keys(self).values():
+        for key_shuffle in get_own_dungeon_prefill_items(self).values():
             self.pre_fill_pool += key_shuffle
+        self.pre_fill_pool += get_any_dungeon_prefill_items(self)
+        self.pre_fill_pool += get_overworld_prefill_items(self)
         self.pre_fill_pool += ShopItems.get_vanilla_shop_pool(self)
 
         if self.using_ut:   # can't this get moved to 'UniversalTracker.py' ?
@@ -301,9 +303,11 @@ class SohWorld(World):
     def pre_fill(self) -> None:
         original_completion_goal = self.multiworld.completion_condition[self.player]
 
-        pre_fill_dungeon(self)
+        pre_fill_own_dungeon_items(self)
+        pre_fill_dungeon_rewards(self)
         pre_fill_songs(self)
-        pre_fill_keys(self)
+        pre_fill_any_dungeon_keys(self)
+        pre_fill_overworld_items(self)
         fill_shop_items(self)
 
         self.multiworld.completion_condition[self.player] = original_completion_goal


### PR DESCRIPTION
Splits the key prefill into three stages, own_dungeon, any_dungeon and overworld

this allows us to perform own_dungeon item fill first fixing some prefill issues with the bottom of the well keys if song locations were set to dungeon rewards