### PR TITLE
Fix shared Gold Skulltula Token items causing broken location references

### DIFF
--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -461,28 +461,27 @@ def place_locked_items(world: "SohWorld") -> None:
     if not world.options.shuffle_shops:
         no_shop_shuffle(world)
 
-    token_item_progressive = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True, ItemClassification.progression_deprioritized_skip_balancing)
-    token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)
-
-    # Preplace tokens based on settings.    
+    # Preplace tokens based on settings.
     if world.options.shuffle_skull_tokens == "off" or world.options.shuffle_skull_tokens == "dungeon":
         for location_name, address in gold_skulltula_overworld_location_table.items():
             if world.vanilla_progressive_skulltula_count > 0:
-                world.get_location(location_name).place_locked_item(token_item_progressive)
+                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True, ItemClassification.progression_deprioritized_skip_balancing)
                 world.vanilla_progressive_skulltula_count -= 1
             else:
-                world.get_location(location_name).place_locked_item(token_item)
-            world.get_location(location_name).address = None 
+                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)
+            world.get_location(location_name).place_locked_item(token_item)
+            world.get_location(location_name).address = None
             world.get_location(location_name).item.code = None
 
     if world.options.shuffle_skull_tokens == "off" or world.options.shuffle_skull_tokens == "overworld":
         for location_name, address in gold_skulltula_dungeon_location_table.items():
             if world.vanilla_progressive_skulltula_count > 0:
-                world.get_location(location_name).place_locked_item(token_item_progressive)
+                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True, ItemClassification.progression_deprioritized_skip_balancing)
                 world.vanilla_progressive_skulltula_count -= 1
             else:
-                world.get_location(location_name).place_locked_item(token_item)
-            world.get_location(location_name).address = None 
+                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)
+            world.get_location(location_name).place_locked_item(token_item)
+            world.get_location(location_name).address = None
             world.get_location(location_name).item.code = None
 
     # Boss Keys


### PR DESCRIPTION
`create_item()` was called once outside the loops and the same item object was reused across all GS locations. Since `place_locked_item()` sets `item.location = location`, the shared item ended up pointing to whichever location was processed last.

Move the `create_item` call inside of the loop so each location gets its own item.

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

Found this using this [fuzzer hook](https://github.com/Mysteryem/Archipelago-fuzzer/blob/mysteryem_hooks/hooks/check_placement_item_location_references.py). 