### PR TITLE
Add affordable price options

### DIFF
--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -1274,6 +1274,34 @@ class StartingHearts(Range):
     range_end = 20
     default = 3
 
+
+class ShopAffordablePrices(Toggle):
+    """
+    After choosing a price range, set it to the affordable amount based on the wallet requirement.
+    Affordable prices per tier: starter=1, adult=100, giant=201, tycoon=501
+    Use this to enable wallet tier locking, but making shop itmes not as expensive as they could be
+    """
+    display_name = "Shop Affordable Prices"
+
+
+class ScrubAffordablePrices(Toggle):
+    """
+    After choosing a price range, set it to the affordable amount based on the wallet requirement.
+    Affordable prices per tier: starter=1, adult=100, giant=201, tycoon=501
+    Use this to enable wallet tier locking, but making shop itmes not as expensive as they could be
+    """
+    display_name = "Scrub Affordable Prices"
+
+
+class MerchantAffordablePrices(Toggle):
+    """
+    After choosing a price range, set it to the affordable amount based on the wallet requirement.
+    Affordable prices per tier: starter=1, adult=100, giant=201, tycoon=501
+    Use this to enable wallet tier locking, but making shop itmes not as expensive as they could be
+    """
+    display_name = "Merchant Affordable Prices"
+
+
 @dataclass
 class SohOptions(PerGameCommonOptions):
     closed_forest: ClosedForest
@@ -1406,6 +1434,9 @@ class SohOptions(PerGameCommonOptions):
     item_pool: ItemPool
     medallion_locked_trials: MedallionLockedTrials
     starting_hearts: StartingHearts
+    shop_affordable_prices: ShopAffordablePrices
+    scrub_affordable_prices: ScrubAffordablePrices
+    merchant_affordable_prices: MerchantAffordablePrices
 
 
 soh_option_groups = [
@@ -1473,11 +1504,13 @@ soh_option_groups = [
         ShuffleShopsItemAmount,
         ShuffleShopsMinimumPrice,
         ShuffleShopsMaximumPrice,
+        ShopAffordablePrices,
         # Other shop weight stuff
         ShuffleFish,
         ShuffleScrubs,
         ShuffleScrubsMinimumPrice,
         ShuffleScrubsMaximumPrice,
+        ScrubAffordablePrices,
         ShuffleBeehives,
         ShuffleCows,
         ShufflePots,
@@ -1486,6 +1519,7 @@ soh_option_groups = [
         ShuffleMerchants,
         ShuffleMerchantsMinimumPrice,
         ShuffleMerchantsMaximumPrice,
+        MerchantAffordablePrices,
         ShuffleFrogSongRupees,
         ShuffleAdultTradeItems,
         Shuffle100GSReward,

--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -278,7 +278,7 @@ def generate_shop_prices(world: "SohWorld") -> dict[Locations, int]:
 
     for region, shop in all_shop_locations:
         for slot in shop.keys():
-            prices[slot] = create_random_price(min_shop_price, max_shop_price, world)
+            prices[slot] = create_random_price(min_shop_price, max_shop_price, world.options.shop_affordable_prices, world)
     return prices
 
 
@@ -292,12 +292,10 @@ def generate_scrub_prices(world: "SohWorld") -> dict[Locations, int]:
     
     if world.options.shuffle_scrubs == "all":
         for slot in scrubs_location_table.keys():
-            prices[slot] = create_random_price(
-                min_scrub_price, max_scrub_price, world)
+            prices[slot] = create_random_price(min_scrub_price, max_scrub_price, world.options.scrub_affordable_prices, world)
     else:
         for slot in scrubs_one_time_only:
-            prices[slot] = create_random_price(
-                min_scrub_price, max_scrub_price, world)
+            prices[slot] = create_random_price(min_scrub_price, max_scrub_price, world.options.scrub_affordable_prices, world)
 
     return prices
 
@@ -316,17 +314,33 @@ def generate_merchant_prices(world: "SohWorld") -> dict[Locations, int]:
         if world.options.shuffle_merchants == "all_but_beans" and slot == Locations.ZR_MAGIC_BEAN_SALESMAN:
             continue
 
-        prices[slot] = create_random_price(min_merchant_price, max_merchant_price, world)
+        prices[slot] = create_random_price(min_merchant_price, max_merchant_price, world.options.merchant_affordable_prices, world)
 
     return prices
 
 
-def create_random_price(min_price: int, max_price: int, world: "SohWorld") -> int:
+affordable_prices: list[int] = [1,101,201,501]
+
+def create_random_price(min_price: int, max_price: int, affordable: bool, world: "SohWorld") -> int:
     # randrange needs an actual range to work, so just pick the price directly if min/max are the same.
     if min_price == max_price:
         price = min_price
     else:
         price = world.random.randrange(min_price, max_price)
 
-    price = price - (price % 5)
+    if affordable:
+        # update to nearest affordable price
+        if price not in affordable_prices:
+            for index, affordable_price in enumerate(affordable_prices, 1):
+                # Tycoon shuffled and it is above 501
+                if index == len(affordable_prices):
+                    price = affordable_price
+                # Else if the price is below the next index set it to this index's price
+                elif affordable_prices[index] > price:
+                    price = affordable_price
+                    break
+    else:
+        # otherwise round down to the nearest multiple of 5
+        price = price - (price % 5)
+
     return price

--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -319,7 +319,7 @@ def generate_merchant_prices(world: "SohWorld") -> dict[Locations, int]:
     return prices
 
 
-affordable_prices: list[int] = [1,101,201,501]
+affordable_prices: list[int] = [1,100,201,501]
 
 def create_random_price(min_price: int, max_price: int, affordable: bool, world: "SohWorld") -> int:
     # randrange needs an actual range to work, so just pick the price directly if min/max are the same.

--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -322,24 +322,23 @@ def generate_merchant_prices(world: "SohWorld") -> dict[Locations, int]:
 affordable_prices: list[int] = [1,100,201,501]
 
 def create_random_price(min_price: int, max_price: int, affordable: bool, world: "SohWorld") -> int:
-    # randrange needs an actual range to work, so just pick the price directly if min/max are the same.
-    if min_price == max_price:
-        price = min_price
-    else:
-        price = world.random.randrange(min_price, max_price)
-
     if affordable:
         # update to nearest affordable price
-        if price not in affordable_prices:
-            for index, affordable_price in enumerate(affordable_prices, 1):
-                # Tycoon shuffled and it is above 501
-                if index == len(affordable_prices):
-                    price = affordable_price
-                # Else if the price is below the next index set it to this index's price
-                elif affordable_prices[index] > price:
-                    price = affordable_price
-                    break
+        price_tier = world.random.randrange(0, 4 if world.options.shuffle_tycoon_wallet else 3)
+        
+        # Try to adhere to their max
+        while affordable_prices[price_tier] > max_price:
+            if price_tier == 0:
+                break
+            price_tier -= 1
+        price = affordable_prices[price_tier]
     else:
+        # randrange needs an actual range to work, so just pick the price directly if min/max are the same.
+        if min_price == max_price:
+            price = min_price
+        else:
+            price = world.random.randrange(min_price, max_price)
+
         # otherwise round down to the nearest multiple of 5
         price = price - (price % 5)
 


### PR DESCRIPTION
If affordable prices in enabled for shops/scrubs/merchants, it will search for the nearest affordable price. These affordable prices are the minimum amount of money based on each wallet size.

So for example, if the players price range on shops is:
min: 10
max: 999

when a random price is determined, lets say 249, that price will be compared to our `affordable_prices` list to determine what the affordable price would be. In this case it would be 201 as the lowest price the Giant Wallet allows for.