### PR TITLE
Fix vanilla tokens in UT.

### DIFF
--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -485,22 +485,14 @@ def place_locked_items(world: "SohWorld") -> None:
     # Preplace tokens based on settings.
     if world.options.shuffle_skull_tokens == "off" or world.options.shuffle_skull_tokens == "dungeon":
         for location_name, address in gold_skulltula_overworld_location_table.items():
-            if world.vanilla_progressive_skulltula_count > 0:
-                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)
-                world.vanilla_progressive_skulltula_count -= 1
-            else:
-                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True, ItemClassification.useful)
+            token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)
             world.get_location(location_name).place_locked_item(token_item)
             world.get_location(location_name).address = None
             world.get_location(location_name).item.code = None
 
     if world.options.shuffle_skull_tokens == "off" or world.options.shuffle_skull_tokens == "overworld":
         for location_name, address in gold_skulltula_dungeon_location_table.items():
-            if world.vanilla_progressive_skulltula_count > 0:
-                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)
-                world.vanilla_progressive_skulltula_count -= 1
-            else:
-                token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True, ItemClassification.useful)
+            token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN, True)
             world.get_location(location_name).place_locked_item(token_item)
             world.get_location(location_name).address = None
             world.get_location(location_name).item.code = None

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -90,7 +90,6 @@ class SohWorld(World):
         self.shop_prices = dict[Locations, int]()
         self.shop_vanilla_items = dict[str, str]()
         self.triforce_pieces_required: int = 0
-        self.vanilla_progressive_skulltula_count: int = 0
         self.randomized_progressive_skulltula_count: int = 0
         self.ganons_trials = list[GanonsTrials]()
         self.pre_fill_pool = list[Items]()
@@ -166,14 +165,13 @@ class SohWorld(World):
                                                self.options.ganons_castle_boss_key_skull_tokens_required.value if self.options.ganons_castle_boss_key.value == 7 else 0, turn_in_amount)
 
         if self.options.shuffle_skull_tokens:
+            vanilla_progressive_skulltula_count = 0
             if self.options.shuffle_skull_tokens == "dungeon":
-                self.vanilla_progressive_skulltula_count = max(progressive_skulltula_count - int(TokenCounts.DUNGEON), 0)
+                vanilla_progressive_skulltula_count = max(progressive_skulltula_count - int(TokenCounts.DUNGEON), 0)
             elif self.options.shuffle_skull_tokens == "overworld":
-                self.vanilla_progressive_skulltula_count = max(progressive_skulltula_count - int(TokenCounts.OVERWORLD), 0)
+                vanilla_progressive_skulltula_count = max(progressive_skulltula_count - int(TokenCounts.OVERWORLD), 0)
                 
-            self.randomized_progressive_skulltula_count = progressive_skulltula_count - self.vanilla_progressive_skulltula_count
-        else:
-            self.vanilla_progressive_skulltula_count = progressive_skulltula_count
+            self.randomized_progressive_skulltula_count = progressive_skulltula_count - vanilla_progressive_skulltula_count
 
         # Figure out Keyring Situation
         key_ring_options: list = [self.options.gerudo_fortress_key_ring, self.options.forest_temple_key_ring, self.options.fire_temple_key_ring, self.options.water_temple_key_ring,


### PR DESCRIPTION
The Token events need to be progression for them to work correctly in UT.

We no longer need to store how many calculated vanilla progression tokens there are because all will be.  We do still need to calculate it though as it determines how many progression random tokens are put in the pool.