### PR TITLE
Make SOH Client

### DIFF
--- a/worlds/oot_soh/Client.py
+++ b/worlds/oot_soh/Client.py
@@ -1,0 +1,62 @@
+import asyncio
+import os
+import json
+from CommonClient import get_base_parser, handle_url_arg
+from . import SohWorld
+
+def launch(*launch_args: str):
+    async def main():
+        hostname = None
+        username = None
+        password = None
+
+        parser = get_base_parser(description="Ship of Harkinian Client")
+        parser.add_argument('--name', default=None, help="Slot Name to connect as.")
+        args, uri = parser.parse_known_args(launch_args)
+
+        if uri and uri[0].startswith('archipelago://'):
+            args.url = uri[0]
+            handle_url_arg(args, parser)
+            hostname = ':'.join([args.url.hostname, str(args.url.port)])
+            username = args.name
+            password = "" if args.password == "None" else args.password
+
+        path = SohWorld.settings.soh_install_path
+        if path is not None:
+            directory, filename = os.path.split(path)
+
+            # Parse JSON to update credentials
+            if hostname is not None:
+                settings = dict()
+                if os.path.isfile(os.path.join(directory, "shipofharkinian.json")):
+                    with open(os.path.join(directory, "shipofharkinian.json"), "r", encoding="utf-8") as settings_file:
+                        settings = json.load(settings_file)
+
+                if "CVars" not in settings:
+                    settings["CVars"] = {}
+
+                if "gRemote" not in settings["CVars"]:
+                    settings["CVars"]["gRemote"] = {}
+
+                if "Archipelago" not in settings["CVars"]["gRemote"]:
+                    settings["CVars"]["gRemote"]["Archipelago"] = {}
+
+                settings["CVars"]["gRemote"]["Archipelago"]["ServerAddress"] = hostname
+                settings["CVars"]["gRemote"]["Archipelago"]["SlotName"] = username
+                settings["CVars"]["gRemote"]["Archipelago"]["Password"] = password
+
+                with open(os.path.join(directory, "shipofharkinian.json"), "w", encoding="utf-8") as settings_file:
+                    json.dump(settings, settings_file, indent=4)#, sort_keys=True)
+
+            # Open Ship
+            proc = await asyncio.create_subprocess_exec(
+                path,
+                cwd=directory,
+                stdout=None,
+                stderr=None
+            )
+
+            # Wait for the process to finish and get output
+            await proc.wait()
+
+    asyncio.run(main())

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -23,6 +23,7 @@ from .UniversalTracker import setup_options_from_slot_data
 from settings import Group, Bool
 from Options import OptionError
 from .LogicHelpers import wallet_capacities
+from worlds.LauncherComponents import Component, components, Type, launch as launch_component
 
 import logging
 logger = logging.getLogger("SOH_OOT")
@@ -60,8 +61,14 @@ class SohSettings(Group):
         By default when an item can't be placed in prefill it will be added to the item pool as a backup. This disables that behavoir.
         """
 
+    class SOHInstallPath(str):
+        """
+        Where the game is installed. Used for opening the game through the AP launcher or Webhost
+        """
+
     allow_true_no_logic: AllowTrueNoLogic | bool = False
     disable_fill_overflow: DisableFillOverflow | bool = False
+    soh_install_path: SOHInstallPath | None = None
 
 
 class SohWorld(World):
@@ -554,3 +561,10 @@ class SohWorld(World):
             "medallion_locked_trials": self.options.medallion_locked_trials.value,
             "starting_hearts": self.options.starting_hearts.value
         }
+
+def launch_client(*args: str):
+    from .Client import launch
+    launch_component(launch, name="Ship of Harkinian Client", args=args)
+
+if SohWorld.settings.soh_install_path is not None:
+    components.append(Component("Ship Of Harkinian Client", game_name="Ship of Harkinian", func=launch_client, component_type=Type.CLIENT, supports_uri=True))


### PR DESCRIPTION
This allows ship to be launched from the AP launcher. The user can choose what install of Ship to use from the host.yaml file.

This also allows launching the client through the webhost -> AP Launcher -> SOH client, passing the slots credentials to update the shipofharkinian.json so the player is ready to connect without having to enter things themselves.

This was tested through linux. I think this would also work for windows. I am unsure about mac.