### PR TITLE
refactor-force-child-start: Minor Refactor of forced child start logic detection

### DIFF
--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -1438,6 +1438,30 @@ class SohOptions(PerGameCommonOptions):
     scrub_affordable_prices: ScrubAffordablePrices
     merchant_affordable_prices: MerchantAffordablePrices
 
+    def apply_any_required_option_adjustments(self):
+        self.adjust_for_forced_child_starts()
+
+    def adjust_for_forced_child_starts(self):
+        # We don't care about any of this if no logic is enabled
+        if self.true_no_logic:
+            return False
+
+        # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
+        if self.door_of_time == DoorOfTime.option_closed and (
+            any([self.shuffle_dungeon_rewards == ShuffleDungeonRewards.option_off,
+                    self.shuffle_ocarinas == ShuffleOcarinas,
+                    self.shuffle_songs == ShuffleSongs.option_off])):
+            return True
+
+        # If door of time is set to song only and songs aren't shuffled, force child spawn
+        if all([self.door_of_time == DoorOfTime.option_song_only, self.shuffle_songs == ShuffleSongs.option_off]):
+            return True
+        
+        # If closed forest is on, force child spawn. Will need additional logic when entrance shuffle is added in future.
+        if self.closed_forest == ClosedForest.option_on:
+            return True
+        return False
+
 
 soh_option_groups = [
     OptionGroup("Area Access", [

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -111,12 +111,13 @@ class SohWorld(World):
                               "your host.yaml settings.")
 
         def is_child_start_forced() -> bool:
+            # We don't care about any of this if no logic is enabled
             if self.options.true_no_logic:
                 return False
 
             # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
-            if self.options.door_of_time.value == Options.DoorOfTime.option_closed and (
-                any([self.options.shuffle_dungeon_rewards.value == Options.ShuffleDungeonRewards.option_off,
+            if self.options.door_of_time == Options.DoorOfTime.option_closed and (
+                any([self.options.shuffle_dungeon_rewards == Options.ShuffleDungeonRewards.option_off,
                      self.options.shuffle_ocarinas == Options.ShuffleOcarinas,
                      self.options.shuffle_songs == Options.ShuffleSongs.option_off])):
                 return True

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -110,29 +110,7 @@ class SohWorld(World):
                               "setting has not been enabled. Either have them disable that option, or enable it in "
                               "your host.yaml settings.")
 
-        def is_child_start_forced() -> bool:
-            # We don't care about any of this if no logic is enabled
-            if self.options.true_no_logic:
-                return False
-
-            # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
-            if self.options.door_of_time == Options.DoorOfTime.option_closed and (
-                any([self.options.shuffle_dungeon_rewards == Options.ShuffleDungeonRewards.option_off,
-                     self.options.shuffle_ocarinas == Options.ShuffleOcarinas,
-                     self.options.shuffle_songs == Options.ShuffleSongs.option_off])):
-                return True
-
-            # If door of time is set to song only and songs aren't shuffled, force child spawn
-            if all([self.options.door_of_time == Options.DoorOfTime.option_song_only, self.options.shuffle_songs == Options.ShuffleSongs.option_off]):
-                return True
-            
-            # If closed forest is on, force child spawn. Will need additional logic when entrance shuffle is added in future.
-            if self.options.closed_forest == Options.ClosedForest.option_on:
-                return True
-            return False
-
-        if is_child_start_forced():
-            self.options.starting_age.value = Options.StartingAge.option_child
+        self.options.apply_any_required_option_adjustments()
 
         # Check if Tycoon Wallet is shuffled and if price settings are above what Giants Wallet can hold. Max/Min Prices need to be adjusted to fit in Giants Wallet.
         if not self.options.shuffle_tycoon_wallet.value:

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -110,17 +110,28 @@ class SohWorld(World):
                               "setting has not been enabled. Either have them disable that option, or enable it in "
                               "your host.yaml settings.")
 
-        # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
-        if self.options.door_of_time.value == 0 and (
-                self.options.shuffle_dungeon_rewards.value == 0 or self.options.shuffle_ocarinas == 0 or self.options.shuffle_songs == "off"):
-            self.options.starting_age.value = 0
+        def is_child_start_forced() -> bool:
+            if self.options.true_no_logic:
+                return False
 
-        # If the door of time is set to song only, and the songs aren't shuffled, force child spawn
-        if self.options.door_of_time == 1 and (self.options.shuffle_songs == "off"):
-            self.options.starting_age.value = 0
+            # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
+            if self.options.door_of_time.value == Options.DoorOfTime.option_closed and (
+                any([self.options.shuffle_dungeon_rewards.value == Options.ShuffleDungeonRewards.option_off,
+                     self.options.shuffle_ocarinas == Options.ShuffleOcarinas,
+                     self.options.shuffle_songs == Options.ShuffleSongs.option_off])):
+                return True
 
-        if self.options.closed_forest == "on":
-            self.options.starting_age.value = 0
+            # If door of time is set to song only and songs aren't shuffled, force child spawn
+            if all([self.options.door_of_time == Options.DoorOfTime.option_song_only, self.options.shuffle_songs == Options.ShuffleSongs.option_off]):
+                return True
+            
+            # If closed forest is on, force child spawn. Will need additional logic when entrance shuffle is added in future.
+            if self.options.closed_forest == Options.ClosedForest.option_on:
+                return True
+            return False
+
+        if is_child_start_forced():
+            self.options.starting_age.value = Options.StartingAge.option_child
 
         # Check if Tycoon Wallet is shuffled and if price settings are above what Giants Wallet can hold. Max/Min Prices need to be adjusted to fit in Giants Wallet.
         if not self.options.shuffle_tycoon_wallet.value:


### PR DESCRIPTION
# Description

Minor refactor of the existing forced child start logic. Change summary:

- Adding a no logic check to mirror existing Ship logic found here: [ship code](https://github.com/HarbourMasters/Shipwright/blob/4e1e180d21155500beea289d203cfa3f9e37fcff/soh/soh/Enhancements/randomizer/settings.cpp#L2455)
- Bundling forced child logic into one inner function
- Using any() and all() to try to make multiline conditionals a little bit nicer to read
- Moving away from magic number checks to referencing the specific field in Options.
  - There might be a story behind this one, happy to revert if so. Seems like a good way to end up with a non-obvious logic error from a typo though
- Trying to remove checks with .value when possible 

## What is this fixing or adding?

Doesn't directly fix anything, I just got sick of jumping between Options.py and __init__py to see what the actual conditions we were testing were. Thought a small PR with just this would be a good place to start

## How was this tested?
- Ran the fuzzer and generated 10 seeds with starting_age: 1  and each of the logic cases for forced child starts. Then verified all the seeds were child starts
  - Example: [meta-fuzz.yaml](https://github.com/user-attachments/files/26538536/meta-fuzz.yaml) 
  - I couldn't get the fuzzer to pass in true_no_logic as an option to test with. I didn't look into it too deeply as it doesn't make sense to use it to do no logic stuff. I was just being lazy with making multiple seeds at once
- Ran unit tests via GitHub Actions on my fork. One fail that looks pretty unrelated/existing. Will investigate when it's not midnight:
  - `FAILED worlds/oot_soh/test/test_time.py::TestTime::test_wrong_age_grass - AttributeError: type object 'Tricks' has no attribute 'DC_HAMMER_FLOOR'` 
