### PR TITLE
Moving additional Option-based setting overrides and calculations to Options.py

### DIFF
--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -1438,6 +1438,30 @@ class SohOptions(PerGameCommonOptions):
     scrub_affordable_prices: ScrubAffordablePrices
     merchant_affordable_prices: MerchantAffordablePrices
 
+    def apply_any_required_option_adjustments(self):
+        self.adjust_for_forced_child_starts()
+
+    def adjust_for_forced_child_starts(self):
+        # We don't care about any of this if no logic is enabled
+        if self.true_no_logic:
+            return False
+
+        # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
+        if self.door_of_time == DoorOfTime.option_closed and (
+            any([self.shuffle_dungeon_rewards == ShuffleDungeonRewards.option_off,
+                    self.shuffle_ocarinas == ShuffleOcarinas,
+                    self.shuffle_songs == ShuffleSongs.option_off])):
+            return True
+
+        # If door of time is set to song only and songs aren't shuffled, force child spawn
+        if all([self.door_of_time == DoorOfTime.option_song_only, self.shuffle_songs == ShuffleSongs.option_off]):
+            return True
+        
+        # If closed forest is on, force child spawn. Will need additional logic when entrance shuffle is added in future.
+        if self.closed_forest == ClosedForest.option_on:
+            return True
+        return False
+
 
 soh_option_groups = [
     OptionGroup("Area Access", [

--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -1475,7 +1475,6 @@ class SohOptions(PerGameCommonOptions):
             for price in prices_to_check:
                 if price > wallet_capacity:
                     price = wallet_capacity 
-
             
     def enforce_maximum_price_larger_than_minimum(self):
         # If maximum price is below minimum, set max to minimum.
@@ -1488,7 +1487,6 @@ class SohOptions(PerGameCommonOptions):
 
         if self.shuffle_merchants_minimum_price > self.shuffle_merchants_maximum_price:
             self.shuffle_merchants_maximum_price.value = self.shuffle_merchants_minimum_price.value
-
 
     def empty_ammo_bags_if_selected(self):
         if self.shuffle_deku_stick_bag:
@@ -1510,6 +1508,8 @@ class SohOptions(PerGameCommonOptions):
         else:
             # If neither of the above options are on, find the first non-excluded location in the token turn ins
             # This assumes that the locations are in descending order of token amounts e.g. 50 -> 40 -> 30 
+            # TODO: exclude_locations doesn't seem to exist?? I've made a best guess on what's intended here
+            # will need to follow up before merge to see what the go is here
             for location, amount in token_amounts.items():
                 if str(location) not in self.exclude_locations:
                     turn_in_amount = amount
@@ -1521,9 +1521,9 @@ class SohOptions(PerGameCommonOptions):
         rainbow_bridge_tokens = 0
         ganons_castle_boss_key = 0
         
-        if self.rainbow_bridge == RainbowBridge.option_skull_tokens:
+        if self.rainbow_bridge == RainbowBridge.option_tokens:
             rainbow_bridge_tokens = self.rainbow_bridge_skull_tokens_required.value
-        if self.ganons_castle_boss_key == GanonsCastleBossKey.option_skull_tokens:
+        if self.ganons_castle_boss_key == GanonsCastleBossKey.option_lacs_skull_tokens:
             ganons_castle_boss_key = self.ganons_castle_boss_key_skull_tokens_required.value
         
         progressive_skulltula_count = max(progressive_skulltula_count, rainbow_bridge_tokens, ganons_castle_boss_key)

--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from Options import Choice, Toggle, DefaultOnToggle, Range, PerGameCommonOptions, StartInventoryPool, Visibility, OptionGroup, OptionSet
-from .Enums import Tricks
+from .Enums import Tricks, TokenCounts
 
 
 class ClosedForest(Choice):
@@ -1439,9 +1439,9 @@ class SohOptions(PerGameCommonOptions):
     merchant_affordable_prices: MerchantAffordablePrices
 
     def apply_any_required_option_adjustments(self):
-        self.adjust_for_forced_child_starts()
+        self.enforce_starting_age_rules()
 
-    def adjust_for_forced_child_starts(self):
+    def enforce_starting_age_rules(self):
         # We don't care about any of this if no logic is enabled
         if self.true_no_logic:
             return False
@@ -1456,11 +1456,95 @@ class SohOptions(PerGameCommonOptions):
         # If door of time is set to song only and songs aren't shuffled, force child spawn
         if all([self.door_of_time == DoorOfTime.option_song_only, self.shuffle_songs == ShuffleSongs.option_off]):
             return True
-        
+
         # If closed forest is on, force child spawn. Will need additional logic when entrance shuffle is added in future.
         if self.closed_forest == ClosedForest.option_on:
             return True
         return False
+    
+    def apply_price_ceiling_to_shop_prices(self, wallet_capacity):
+        prices_to_check = [
+            self.shuffle_shops_minimum_price, 
+            self.shuffle_shops_maximum_price, 
+            self.shuffle_scrubs_minimum_price, 
+            self.shuffle_scrubs_maximum_price, 
+            self.shuffle_merchants_minimum_price, 
+            self.shuffle_merchants_maximum_price
+        ]
+        if not self.shuffle_tycoon_wallet:
+            for price in prices_to_check:
+                if price > wallet_capacity:
+                    price = wallet_capacity 
+
+            
+    def enforce_maximum_price_larger_than_minimum(self):
+        # If maximum price is below minimum, set max to minimum.
+        
+        if self.shuffle_shops_minimum_price > self.shuffle_shops_maximum_price:
+            self.shuffle_shops_maximum_price.value = self.shuffle_shops_minimum_price.value
+
+        if self.shuffle_scrubs_minimum_price > self.shuffle_scrubs_maximum_price:
+            self.shuffle_scrubs_maximum_price.value = self.shuffle_scrubs_minimum_price.value
+
+        if self.shuffle_merchants_minimum_price > self.shuffle_merchants_maximum_price:
+            self.shuffle_merchants_maximum_price.value = self.shuffle_merchants_minimum_price.value
+
+
+    def empty_ammo_bags_if_selected(self):
+        if self.shuffle_deku_stick_bag:
+            self.start_with_stick_ammo.value = 0
+
+        if self.shuffle_deku_nut_bag:
+            self.start_with_nut_ammo.value = 0
+
+    def calculate_progressive_skulltula_count(self, token_amounts):
+        # Start by assuming that there are no progressive skulltula tokens
+        progressive_skulltula_count = 0 
+
+        # Figure out the turn in amount required based on 100gs reward and accessibility settings
+        turn_in_amount = 0
+        if self.shuffle_100_gs_reward:
+            turn_in_amount = 100
+        elif self.accessibility == "full":
+            turn_in_amount = 50
+        else:
+            # If neither of the above options are on, find the first non-excluded location in the token turn ins
+            # This assumes that the locations are in descending order of token amounts e.g. 50 -> 40 -> 30 
+            for location, amount in token_amounts.items():
+                if str(location) not in self.exclude_locations:
+                    turn_in_amount = amount
+                    break
+        progressive_skulltula_count = max(progressive_skulltula_count, turn_in_amount)
+ 
+        # Then we need to know if there's any other token count requirements. This is for things like 
+        # Skulltula requires for Rainbow Bridge or Ganon's Castle Boss Key
+        rainbow_bridge_tokens = 0
+        ganons_castle_boss_key = 0
+        
+        if self.rainbow_bridge == RainbowBridge.option_skull_tokens:
+            rainbow_bridge_tokens = self.rainbow_bridge_skull_tokens_required.value
+        if self.ganons_castle_boss_key == GanonsCastleBossKey.option_skull_tokens:
+            ganons_castle_boss_key = self.ganons_castle_boss_key_skull_tokens_required.value
+        
+        progressive_skulltula_count = max(progressive_skulltula_count, rainbow_bridge_tokens, ganons_castle_boss_key)
+
+        # Finally, we need to calculate token requirements based on token shuffle settings based on the locations they can be shuffled in
+        # It should break down to the following:
+        #     - ALL shuffle: all tokens are progressive (100)
+        #     - Dungeon shuffle: all dungeon tokens are progressive (44)
+        #     - Overworld shuffle: all overworld tokens are progressive (56)
+
+        shuffled_skulltulas = 0
+        if self.shuffle_skull_tokens.option_all:
+            shuffled_skulltulas = 100
+        elif self.shuffle_skull_tokens.option_dungeon:
+            shuffled_skulltulas = int(TokenCounts.DUNGEON)
+        elif self.shuffle_skull_tokens.option_overworld:
+            shuffled_skulltulas = int(TokenCounts.OVERWORLD)
+
+        # Final progressive token count should now be the max of shuffled skulltulas and the previously calculated requirements
+        
+        return max(progressive_skulltula_count, shuffled_skulltulas)
 
 
 soh_option_groups = [

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -110,58 +110,11 @@ class SohWorld(World):
                               "setting has not been enabled. Either have them disable that option, or enable it in "
                               "your host.yaml settings.")
 
-        self.options.apply_any_required_option_adjustments()
-
-        # Check if Tycoon Wallet is shuffled and if price settings are above what Giants Wallet can hold. Max/Min Prices need to be adjusted to fit in Giants Wallet.
-        if not self.options.shuffle_tycoon_wallet.value:
-            for option in (self.options.shuffle_shops_minimum_price, self.options.shuffle_shops_maximum_price, self.options.shuffle_scrubs_minimum_price, self.options.shuffle_scrubs_maximum_price, self.options.shuffle_merchants_minimum_price, self.options.shuffle_merchants_maximum_price):
-                if option.value > wallet_capacities[Items.GIANT_WALLET]:
-                    option.value = wallet_capacities[Items.GIANT_WALLET]
-
-        # If maximum price is below minimum, set max to minimum.
-        if self.options.shuffle_shops_minimum_price.value > self.options.shuffle_shops_maximum_price.value:
-            self.options.shuffle_shops_maximum_price.value = self.options.shuffle_shops_minimum_price.value
-
-        if self.options.shuffle_scrubs_minimum_price.value > self.options.shuffle_scrubs_maximum_price.value:
-            self.options.shuffle_scrubs_maximum_price.value = self.options.shuffle_scrubs_minimum_price.value
-
-        if self.options.shuffle_merchants_minimum_price.value > self.options.shuffle_merchants_maximum_price.value:
-            self.options.shuffle_merchants_maximum_price.value = self.options.shuffle_merchants_minimum_price.value
-
-        if self.options.shuffle_deku_stick_bag.value:
-            self.options.start_with_stick_ammo.value = 0
-
-        if self.options.shuffle_deku_nut_bag.value:
-            self.options.start_with_nut_ammo.value = 0
-
-        if self.options.shuffle_dungeon_rewards in ("off", "end_of_dungeons"):
-            self.options.start_with_links_pocket.value = 0
-
-        # Figure out how many Skulltula tokens need to be progressive
-        # Max amount from KAK turn ins
-        turn_in_amount: int = 0
-
-        if self.options.shuffle_100_gs_reward:
-            turn_in_amount = 100
-        elif self.options.accessibility == "full":
-            turn_in_amount = 50
-        else:
-            for location, amount in token_amounts.items():
-                if str(location) not in self.options.exclude_locations:
-                    turn_in_amount = amount
-                    break
-
-        progressive_skulltula_count: int = max(self.options.rainbow_bridge_skull_tokens_required.value if self.options.rainbow_bridge.value == 6 else 0,
-                                               self.options.ganons_castle_boss_key_skull_tokens_required.value if self.options.ganons_castle_boss_key.value == 7 else 0, turn_in_amount)
-
-        if self.options.shuffle_skull_tokens:
-            vanilla_progressive_skulltula_count = 0
-            if self.options.shuffle_skull_tokens == "dungeon":
-                vanilla_progressive_skulltula_count = max(progressive_skulltula_count - int(TokenCounts.DUNGEON), 0)
-            elif self.options.shuffle_skull_tokens == "overworld":
-                vanilla_progressive_skulltula_count = max(progressive_skulltula_count - int(TokenCounts.OVERWORLD), 0)
-                
-            self.randomized_progressive_skulltula_count = progressive_skulltula_count - vanilla_progressive_skulltula_count
+        self.options.enforce_starting_age_rules()
+        self.options.apply_price_ceiling_to_shop_prices(wallet_capacities[Items.GIANT_WALLET])
+        self.options.enforce_maximum_price_larger_than_minimum()
+        self.options.empty_ammo_bags_if_selected()
+        self.randomized_progressive_skulltula_count = self.options.calculate_progressive_skulltula_count(token_amounts)
 
         # Figure out Keyring Situation
         key_ring_options: list = [self.options.gerudo_fortress_key_ring, self.options.forest_temple_key_ring, self.options.fire_temple_key_ring, self.options.water_temple_key_ring,

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -111,12 +111,13 @@ class SohWorld(World):
                               "your host.yaml settings.")
 
         def is_child_start_forced() -> bool:
+            # We don't care about any of this if no logic is enabled
             if self.options.true_no_logic:
                 return False
 
             # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
-            if self.options.door_of_time.value == Options.DoorOfTime.option_closed and (
-                any([self.options.shuffle_dungeon_rewards.value == Options.ShuffleDungeonRewards.option_off,
+            if self.options.door_of_time == Options.DoorOfTime.option_closed and (
+                any([self.options.shuffle_dungeon_rewards == Options.ShuffleDungeonRewards.option_off,
                      self.options.shuffle_ocarinas == Options.ShuffleOcarinas,
                      self.options.shuffle_songs == Options.ShuffleSongs.option_off])):
                 return True

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -110,29 +110,7 @@ class SohWorld(World):
                               "setting has not been enabled. Either have them disable that option, or enable it in "
                               "your host.yaml settings.")
 
-        def is_child_start_forced() -> bool:
-            # We don't care about any of this if no logic is enabled
-            if self.options.true_no_logic:
-                return False
-
-            # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
-            if self.options.door_of_time == Options.DoorOfTime.option_closed and (
-                any([self.options.shuffle_dungeon_rewards == Options.ShuffleDungeonRewards.option_off,
-                     self.options.shuffle_ocarinas == Options.ShuffleOcarinas,
-                     self.options.shuffle_songs == Options.ShuffleSongs.option_off])):
-                return True
-
-            # If door of time is set to song only and songs aren't shuffled, force child spawn
-            if all([self.options.door_of_time == Options.DoorOfTime.option_song_only, self.options.shuffle_songs == Options.ShuffleSongs.option_off]):
-                return True
-            
-            # If closed forest is on, force child spawn. Will need additional logic when entrance shuffle is added in future.
-            if self.options.closed_forest == Options.ClosedForest.option_on:
-                return True
-            return False
-
-        if is_child_start_forced():
-            self.options.starting_age.value = Options.StartingAge.option_child
+        self.options.apply_any_required_option_adjustments()
 
         # Check if Tycoon Wallet is shuffled and if price settings are above what Giants Wallet can hold. Max/Min Prices need to be adjusted to fit in Giants Wallet.
         if not self.options.shuffle_tycoon_wallet.value:

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -110,17 +110,28 @@ class SohWorld(World):
                               "setting has not been enabled. Either have them disable that option, or enable it in "
                               "your host.yaml settings.")
 
-        # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
-        if self.options.door_of_time.value == 0 and (
-                self.options.shuffle_dungeon_rewards.value == 0 or self.options.shuffle_ocarinas == 0 or self.options.shuffle_songs == "off"):
-            self.options.starting_age.value = 0
+        def is_child_start_forced() -> bool:
+            if self.options.true_no_logic:
+                return False
 
-        # If the door of time is set to song only, and the songs aren't shuffled, force child spawn
-        if self.options.door_of_time == 1 and (self.options.shuffle_songs == "off"):
-            self.options.starting_age.value = 0
+            # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
+            if self.options.door_of_time.value == Options.DoorOfTime.option_closed and (
+                any([self.options.shuffle_dungeon_rewards.value == Options.ShuffleDungeonRewards.option_off,
+                     self.options.shuffle_ocarinas == Options.ShuffleOcarinas,
+                     self.options.shuffle_songs == Options.ShuffleSongs.option_off])):
+                return True
 
-        if self.options.closed_forest == "on":
-            self.options.starting_age.value = 0
+            # If door of time is set to song only and songs aren't shuffled, force child spawn
+            if all([self.options.door_of_time == Options.DoorOfTime.option_song_only, self.options.shuffle_songs == Options.ShuffleSongs.option_off]):
+                return True
+            
+            # If closed forest is on, force child spawn. Will need additional logic when entrance shuffle is added in future.
+            if self.options.closed_forest == Options.ClosedForest.option_on:
+                return True
+            return False
+
+        if is_child_start_forced():
+            self.options.starting_age.value = Options.StartingAge.option_child
 
         # Check if Tycoon Wallet is shuffled and if price settings are above what Giants Wallet can hold. Max/Min Prices need to be adjusted to fit in Giants Wallet.
         if not self.options.shuffle_tycoon_wallet.value:


### PR DESCRIPTION
Follow up the [last PR](http://github.com/HarbourMasters/Archipelago-SoH/pull/191) related to forced child start logic. Moved the additional option based checks to Options.py:

- Merchant prices
- Empty ammo bag starts
- Progressive Gold Skull calculation
  - This one is a bit of a doozy, I think it's way clearer what it does here but could also just be broken into further functions if needed 

## What is this fixing or adding?
Refactoring

## How was this tested?
It hasn't been yet! I want to check in with the approach before getting at this too much

## If this makes graphical changes, please attach screenshots.
