### PR TITLE
Backport fixes from rulebuilder fuzzing

### DIFF
--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from .Enums import *
-from .Items import item_data_table, filler_items, filler_bottles, SohItem
+from .Items import item_data_table, filler_items, no_rules_bottles, SohItem
 from .Regions import dungeon_reward_item_mapping, small_key_vanilla_mapping, dungeon_boss_key_vanilla_mapping
 from .LogicHelpers import key_to_ring, hearts
 from .KeyShuffle import small_key_option_matching
@@ -498,10 +498,26 @@ def create_item_pool(world: "SohWorld") -> None:
         items_to_create[Items.GOLD_SKULLTULA_TOKEN] -= create_special_progression_item(
             world, Items.GOLD_SKULLTULA_TOKEN, ItemClassification.useful | ItemClassification.deprioritized | ItemClassification.skip_balancing, items_to_create[Items.GOLD_SKULLTULA_TOKEN] - world.randomized_progressive_skulltula_count)
 
-    # If hearts aren't logically relevent make the containers useful
-    if not (world.options.enable_all_tricks or str(Tricks.FEWER_TUNIC_REQUIREMENTS) in world.options.tricks_in_logic.value):
+    # If hearts aren't logically relevent (or you have enough to do everything) make them useful
+    min_hearts_needed: int = 3
+    if not (world.options.enable_all_tricks or str(Tricks.FEWER_TUNIC_REQUIREMENTS) in world.options.tricks_in_logic.value or world.multiworld.state.soh_heart_count[world.player] < min_hearts_needed):
+        progression_hearts: int = min_hearts_needed - world.multiworld.state.soh_heart_count[world.player]
+        non_progression_container_amount: int = 0
+        non_progression_piece_amount: int = 0
+        if progression_hearts > 0 and items_to_create[Items.HEART_CONTAINER] > 0:
+            non_progression_container_amount = items_to_create[Items.HEART_CONTAINER] - progression_hearts
+
+        if non_progression_container_amount == 0:
+            non_progression_container_amount = progression_hearts * 4
+
         items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(
-            world, Items.HEART_CONTAINER, ItemClassification.useful | ItemClassification.skip_balancing, items_to_create[Items.HEART_CONTAINER])
+            world, Items.HEART_CONTAINER, ItemClassification.useful | ItemClassification.skip_balancing, non_progression_container_amount)
+        
+        if world.options.item_pool != "minimal":
+            items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(
+                world, Items.PIECE_OF_HEART, ItemClassification.useful | ItemClassification.skip_balancing, non_progression_piece_amount - 1)
+            items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(
+                world, Items.HEART_CONTAINER, ItemClassification.useful | ItemClassification.skip_balancing, 1)
 
     # if Greg isn't necessary to win, make him filler
     if not (world.options.rainbow_bridge == "greg" or (world.options.rainbow_bridge and world.options.rainbow_bridge_greg_modifier) or (world.options.ganons_castle_boss_key and world.options.ganons_castle_boss_key_greg_modifier)):
@@ -600,7 +616,7 @@ def get_filler_item(world: "SohWorld") -> str:
 
 
 def get_filler_bottle(world: "SohWorld") -> str:
-    return world.random.choice(filler_bottles)
+    return world.random.choice(no_rules_bottles)
 
 
 def give_starting_items(world: "SohWorld") -> None:

--- a/worlds/oot_soh/Items.py
+++ b/worlds/oot_soh/Items.py
@@ -229,7 +229,7 @@ item_data_table: dict[Items, SohItemData] = {
     Items.PURPLE_RUPEE: SohItemData(138, IC.filler, 0, tags=GroupTag.Money),
     Items.HUGE_RUPEE: SohItemData(139, IC.filler, 0, tags=GroupTag.Money),
     # 35
-    Items.PIECE_OF_HEART: SohItemData(140, IC.useful | IC.skip_balancing, 0, tags=GroupTag.Health_Upgrade),
+    Items.PIECE_OF_HEART: SohItemData(140, IC.progression_skip_balancing, 0, tags=GroupTag.Health_Upgrade),
     # 8
     Items.HEART_CONTAINER: SohItemData(141, IC.progression_skip_balancing, 0, tags=GroupTag.Health_Upgrade),
     Items.ICE_TRAP: SohItemData(142, IC.trap, 0, tags=GroupTag.Trap),
@@ -252,7 +252,7 @@ item_data_table: dict[Items, SohItemData] = {
     # Items.GREEN_POTION_REFILL: SohItemData( 159, IC.filler, 0 ),
     # Items.BLUE_POTION_REFILL: SohItemData( 160, IC.filler, 0 ),
     # 1
-    Items.PIECE_OF_HEART_WINNER: SohItemData(161, IC.useful | IC.skip_balancing, 0, tags=GroupTag.Health_Upgrade),
+    Items.PIECE_OF_HEART_WINNER: SohItemData(161, IC.progression_skip_balancing, 0, tags=GroupTag.Health_Upgrade),
     # Items.TREASURE_GAME_GREEN_RUPEE: SohItemData( 162, IC.filler, 0 ),
     Items.BUY_DEKU_NUTS5: SohItemData(None, IC.progression, 0, tags=GroupTag.Purchasable_Item),
     Items.BUY_ARROWS30: SohItemData(None, IC.progression, 0, tags=GroupTag.Purchasable_Item),
@@ -406,15 +406,11 @@ no_rules_bottles = [
     Items.BOTTLE_WITH_FISH,
     Items.BOTTLE_WITH_BLUE_FIRE,
     Items.BOTTLE_WITH_BUGS,
-]
-
-filler_bottles = [
-    *no_rules_bottles,
     Items.BOTTLE_WITH_POE,
 ]
 
 all_bottles: list[Items] = [
-    *filler_bottles,
+    *no_rules_bottles,
     Items.BOTTLE_WITH_RUTOS_LETTER,
 ]
 

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -8,6 +8,7 @@ from worlds.generic.Rules import set_rule
 from worlds.AutoWorld import LogicMixin
 from .Enums import *
 from .Items import SohItem, item_data_table, ItemType, no_rules_bottles, GroupTag
+from .Options import wallet_capacities
 
 if TYPE_CHECKING:
     from . import SohWorld
@@ -180,14 +181,6 @@ def has_item(item: Items | Events | StrEnum, bundle: tuple[CollectionState, Regi
         return has_bottle(bundle)
 
     return state.has(item, player, count)
-
-
-wallet_capacities: dict[Items, int] = {
-    Items.CHILD_WALLET: 99,
-    Items.ADULT_WALLET: 200,
-    Items.GIANT_WALLET: 500,
-    Items.TYCOON_WALLET: 999
-}
 
 def can_afford_slot(slot: Locations, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     world = bundle[2]

--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -1,7 +1,13 @@
 from dataclasses import dataclass
 from Options import Choice, Toggle, DefaultOnToggle, Range, PerGameCommonOptions, StartInventoryPool, Visibility, OptionGroup, OptionSet
 from .Enums import Tricks, Items
-from .LogicHelpers import wallet_capacities
+
+wallet_capacities: dict[Items, int] = {
+    Items.CHILD_WALLET: 99,
+    Items.ADULT_WALLET: 200,
+    Items.GIANT_WALLET: 500,
+    Items.TYCOON_WALLET: 999
+}
 
 class ClosedForest(Choice):
     """
@@ -1675,7 +1681,7 @@ class SohOptions(PerGameCommonOptions):
         # If door of time is set to closed and dungeon rewards aren't shuffled or ocarinas aren't shuffled, force child spawn
         if self.door_of_time == DoorOfTime.option_closed and (
             any([self.shuffle_dungeon_rewards == ShuffleDungeonRewards.option_off,
-                    self.shuffle_ocarinas == ShuffleOcarinas,
+                    self.shuffle_ocarinas == ShuffleOcarinas.option_false,
                     self.shuffle_songs == ShuffleSongs.option_off])):
             self.starting_age.value = StartingAge.option_child
             return


### PR DESCRIPTION
These are a bunch of gen failure fixes that were found in the making/validating of rb. Adding them here just in case we wanted to confirm these separate from rb.

The itinerary includes:
1. Bottle fix for regular Poe Bottle + zoras fountain open
2. POH fixes around progression + item pool option + starting hearts
3. Child start missing option value
4. Move wallet capacity to fix circular dependency