### PR TITLE
added dc hammer floor trick back fixes unit test

### DIFF
--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -3654,7 +3654,7 @@ class Tricks(StrEnum):
     DC_SLINGSHOT_SKIP = "DC Slingshot Skip"
     DC_SCRUB_ROOM = "DC Scrub Room"
     DC_JUMP = "DC Jump"
-#    DC_HAMMER_FLOOR = "DC Hammer Floor"
+    DC_HAMMER_FLOOR = "DC Hammer Floor"
 #    DC_MQ_STAIRS_WITH_ONLY_STRENGTH = "DC MQ Stairs With Only Strength"
 #    DC_MQ_CHILD_BOMBS = "DC MQ Child Bombs"
 #    DC_MQ_CHILD_EYES = "DC MQ Child Eyes"


### PR DESCRIPTION
In an [earlier PR](https://github.com/HarbourMasters/Archipelago-SoH/pull/130) I removed a bunch of tricks that didn't have logic attached to them.

Looks like I accidentally removed one too many which later broke a unit test.
This puts the trick back and makes all our tests happy again