### PR TITLE
oot_soh: [Client] support other installation environments

### DIFF
--- a/worlds/oot_soh/Client.py
+++ b/worlds/oot_soh/Client.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import json
+import sys
 from CommonClient import get_base_parser, handle_url_arg
 from Utils import open_directory, open_filename
 from . import SohWorld
@@ -43,9 +44,7 @@ def launch(*launch_args: str):
         # If there is no path to the Ship install, prompt them until there is one
         while executable_path is None or executable_path == "" or not os.path.exists(executable_path):
             try:
-                # Calling realpath on the executable path is unsound in environments where executables are symlinked into place
-                # we should be able to execve(2) through a symlink anyways.
-                # TODO: what other common binary format extensions are there?
+                # Calling realpath on the executable path is unsound in environments where executables are symlinked into place we should be able to exec(3) through a symlink anyways.
                 tempPath = os.path.abspath(open_filename("Select Ship of Harkinian AP Client",  (("Ship of Harkinian AP Client", (".exe", ".appimage", ".elf")), ("Any File", "")), ""))
 
                 # Check this exists
@@ -65,17 +64,16 @@ def launch(*launch_args: str):
                 # Log an error? Unlikely to happen unless they close the file dialog
                 return
 
+        # Similarly for the path to the folder which contains other ship related files, continually prompt until it is valid.
         while settings_folder is None or settings_folder == "" or not os.path.exists(settings_folder):
             try:
-                import sys
-
-                suggestedPath = ""
+                suggested_path = ""
                 if sys.platform == "linux":
-                    suggestedPath = os.path.realpath(os.path.join(os.environ["HOME"], ".local/share"))
-                tempPath = os.path.realpath(open_directory("Select folder containing Ship of Harkinian settings, mods, etc", suggestedPath))
+                    suggested_path = os.path.realpath(os.path.join(os.environ["HOME"], ".local/share"))
+                tempt_path = os.path.realpath(open_directory("Select folder containing Ship of Harkinian settings, mods, etc", suggested_path))
 
-                if os.path.exists(os.path.join(tempPath, "shipofharkinian.json")):
-                    settings_folder = tempPath
+                if os.path.exists(os.path.join(tempt_path, "shipofharkinian.json")):
+                    settings_folder = tempt_path
                     SohWorld.settings.soh_settings_folder = settings_folder
                     force_settings_save_on_close()
 

--- a/worlds/oot_soh/Client.py
+++ b/worlds/oot_soh/Client.py
@@ -44,7 +44,6 @@ def launch(*launch_args: str):
         # If there is no path to the Ship install, prompt them until there is one
         while executable_path is None or executable_path == "" or not os.path.exists(executable_path):
             try:
-                # Calling realpath on the executable path is unsound in environments where executables are symlinked into place we should be able to exec(3) through a symlink anyways.
                 tempPath = os.path.abspath(open_filename("Select Ship of Harkinian AP Client",  (("Ship of Harkinian AP Client", (".exe", ".appimage", ".elf")), ("Any File", "")), ""))
 
                 # Check this exists
@@ -64,7 +63,7 @@ def launch(*launch_args: str):
                 # Log an error? Unlikely to happen unless they close the file dialog
                 return
 
-        # Similarly for the path to the folder which contains other ship related files, continually prompt until it is valid.
+        # Similarly for the path to the folder which contains other ship related files, prompt until it is valid.
         while settings_folder is None or settings_folder == "" or not os.path.exists(settings_folder):
             try:
                 suggested_path = ""

--- a/worlds/oot_soh/Client.py
+++ b/worlds/oot_soh/Client.py
@@ -44,7 +44,7 @@ def launch(*launch_args: str):
         # If there is no path to the Ship install, prompt them until there is one
         while executable_path is None or executable_path == "" or not os.path.exists(executable_path):
             try:
-                tempPath = os.path.abspath(open_filename("Select Ship of Harkinian AP Client",  (("Ship of Harkinian AP Client", (".exe", ".appimage", ".elf")), ("Any File", "")), ""))
+                tempPath = os.path.abspath(open_filename("Select Ship of Harkinian AP Client", (("Ship of Harkinian AP Client", (".exe", ".appimage", ".elf")), ("Any File", "")), ""))
 
                 # Check this exists
                 if os.path.exists(tempPath):

--- a/worlds/oot_soh/Client.py
+++ b/worlds/oot_soh/Client.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import json
 from CommonClient import get_base_parser, handle_url_arg
-from Utils import open_filename
+from Utils import open_directory, open_filename
 from . import SohWorld
 
 # Stolen from SC2 client
@@ -37,25 +37,54 @@ def launch(*launch_args: str):
             username = args.name
             password = "" if args.password == "None" else args.password
 
-        path = SohWorld.settings.soh_install_path
+        executable_path = SohWorld.settings.executable_path
+        settings_folder = SohWorld.settings.soh_settings_folder
 
         # If there is no path to the Ship install, prompt them until there is one
-        while path is None or path == "" or not os.path.exists(path):
+        while executable_path is None or executable_path == "" or not os.path.exists(executable_path):
             try:
-                tempPath = os.path.realpath(open_filename("Select Ship of Harkinian AP Client", (("Ship of Harkinian AP Client", (".exe", ".appimage")), ('Any File', '')), ""))
+                # Calling realpath on the executable path is unsound in environments where executables are symlinked into place
+                # we should be able to execve(2) through a symlink anyways.
+                # TODO: what other common binary format extensions are there?
+                tempPath = os.path.abspath(open_filename("Select Ship of Harkinian AP Client",  (("Ship of Harkinian AP Client", (".exe", ".appimage", ".elf")), ("Any File", "")), ""))
 
                 # Check this exists
                 if os.path.exists(tempPath):
-                    path = tempPath
-                    SohWorld.settings.soh_install_path = path
+                    executable_path = tempPath
+                    SohWorld.settings.executable_path = executable_path
+                    force_settings_save_on_close()
+
+                settings_path = os.path.join(os.path.split(tempPath)[0], "shipofharkinian.json")
+
+                if os.path.exists(settings_path):
+                    settings_folder = os.path.split(settings_path)[0]
+                    SohWorld.settings.soh_settings_folder = settings_folder
                     force_settings_save_on_close()
 
             except Exception as e:
                 # Log an error? Unlikely to happen unless they close the file dialog
                 return
 
-        if path is not None:
-            directory, filename = os.path.split(path)
+        while settings_folder is None or settings_folder == "" or not os.path.exists(settings_folder):
+            try:
+                import sys
+
+                suggestedPath = ""
+                if sys.platform == "linux":
+                    suggestedPath = os.path.realpath(os.path.join(os.environ["HOME"], ".local/share"))
+                tempPath = os.path.realpath(open_directory("Select folder containing Ship of Harkinian settings, mods, etc", suggestedPath))
+
+                if os.path.exists(os.path.join(tempPath, "shipofharkinian.json")):
+                    settings_folder = tempPath
+                    SohWorld.settings.soh_settings_folder = settings_folder
+                    force_settings_save_on_close()
+
+            except Exception as e:
+                # It's also unlikely for errors to occur here.
+                return
+
+        if executable_path is not None and settings_folder is not None:
+            directory = settings_folder
 
             # Parse JSON to update credentials
             if hostname is not None:
@@ -82,7 +111,7 @@ def launch(*launch_args: str):
 
             # Open Ship
             proc = await asyncio.create_subprocess_exec(
-                path,
+                executable_path,
                 cwd=directory,
                 stdout=None,
                 stderr=None

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -62,14 +62,20 @@ class SohSettings(Group):
         By default when an item can't be placed in prefill it will be added to the item pool as a backup. This disables that behavoir.
         """
 
-    class SOHInstallPath(str):
+    class SOHExecutablePath(str):
         """
-        Where the game is installed. Used for opening the game through the AP launcher or Webhost
+        Where the game executable is installed. Used for opening the game through the AP launcher or Webhost
+        """
+
+    class SOHSettingsFolder(str):
+        """
+        Where game files and configuration is contained. Used to change shipofharkinian.json settings
         """
 
     allow_true_no_logic: AllowTrueNoLogic | bool = False
     disable_fill_overflow: DisableFillOverflow | bool = False
-    soh_install_path: SOHInstallPath | None = None
+    executable_path: SOHExecutablePath | None = None
+    soh_settings_folder: SOHSettingsFolder | None = None
 
 
 @staticmethod


### PR DESCRIPTION
## What is this fixing or adding?

Separates the location of the executable (ship) and the folder which contains settings (`shipofharkinian.json`).
The previous instance of the settings being co-located with the executable is assumed and defaulted to.

## How was this tested?
System: `Linux 7.0.1-cachyos-lto x86_64`
Zipping the world folder, adding it to the launcher, making a room and both clicking links in archipelago rooms as well as `xdg-open`-ing them.
Using the windows which pop up, I was able to get archipelago to launch even locally built dev binaries from the `harkipellago` branch, with the correct connection information.

---
Also, because some systems will symlink executables into common locations, I'd caution against trying to `realpath` through a symlink'd executable. If soh-ap installations are managed through a package manager or something akin to one, any update might silently break what is stored in `host.yaml`.