### PR TITLE
Reverse Item Classification of Triforce Pieces 

### DIFF
--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -551,9 +551,9 @@ def create_triforce_pieces(world: "SohWorld") -> None:
     triforce_pieces_to_win: int = max(1, round(
         total_triforce_pieces * (world.options.triforce_hunt_pieces_required_percentage.value * .01)))
 
-    triforce_pieces_made = [world.create_item(
-        Items.TRIFORCE_PIECE, classification=ItemClassification.progression_skip_balancing) for _ in range(triforce_pieces_to_win)]
-    triforce_pieces_made += [world.create_item(Items.TRIFORCE_PIECE)
+    triforce_pieces_made = [world.create_item(Items.TRIFORCE_PIECE) 
+                            for _ in range(triforce_pieces_to_win)]
+    triforce_pieces_made += [world.create_item(Items.TRIFORCE_PIECE, classification=ItemClassification.useful | ItemClassification.skip_balancing) 
                              for _ in range(total_triforce_pieces - triforce_pieces_to_win)]
 
     world.add_items_to_item_pool_list(triforce_pieces_made)

--- a/worlds/oot_soh/Items.py
+++ b/worlds/oot_soh/Items.py
@@ -285,7 +285,7 @@ item_data_table: dict[Items, SohItemData] = {
     Items.BUY_RED_POTION40: SohItemData(None, IC.progression, 0, tags=GroupTag.Purchasable_Item),
     Items.BUY_RED_POTION50: SohItemData(None, IC.progression, 0, tags=GroupTag.Purchasable_Item),
     # Items.TRIFORCE: SohItemData( 193, IC.progression, 0 ),
-    Items.TRIFORCE_PIECE: SohItemData(194, IC.useful | IC.skip_balancing, 0, tags=GroupTag.Golden_Item),
+    Items.TRIFORCE_PIECE: SohItemData(194, IC.progression_skip_balancing, 0, tags=GroupTag.Golden_Item),
     Items.GOHMAS_SOUL: SohItemData(195, IC.progression, 0, tags=GroupTag.Boss_Soul | GroupTag.Deku_Tree_Item),
     Items.KING_DODONGOS_SOUL: SohItemData(196, IC.progression, 0, tags=GroupTag.Boss_Soul | GroupTag.Dodongos_Cavern_Item),
     Items.BARINADES_SOUL: SohItemData(197, IC.progression, 0, tags=GroupTag.Boss_Soul | GroupTag.Jabu_Jabus_Item),


### PR DESCRIPTION
This was done for other items, but not Triforce Pieces. Essentially anything that could be required for progression, should be created as that by default. 

In situations where they are created not from our code, such as UT or start item from pool, the users likely wants them to be considered progression.