### PR TITLE
Fix SHADOW_TEMPLE_GS_SINGLE_GIANT_POT rule

### DIFF
--- a/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
+++ b/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
@@ -81,7 +81,7 @@ def set_region_rules(world: "SohWorld") -> None:
     add_locations(Regions.GERUDO_TRAINING_GROUND_LAVA_ROOM, world, [
         (Locations.GERUDO_TRAINING_GROUND_UNDERWATER_SILVER_RUPEE_CHEST,
          lambda bundle: can_use(Items.HOOKSHOT, bundle) and can_use(Items.SONG_OF_TIME, bundle) and can_use(
-             Items.IRON_BOOTS, bundle) and water_timer(bundle) >= 24 and has_item(Items.BRONZE_SCALE)),
+             Items.IRON_BOOTS, bundle) and water_timer(bundle) >= 24 and has_item(Items.BRONZE_SCALE, bundle)),
     ])
     # Connections
     connect_regions(Regions.GERUDO_TRAINING_GROUND_LAVA_ROOM, world, [

--- a/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
+++ b/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
@@ -81,7 +81,7 @@ def set_region_rules(world: "SohWorld") -> None:
     add_locations(Regions.GERUDO_TRAINING_GROUND_LAVA_ROOM, world, [
         (Locations.GERUDO_TRAINING_GROUND_UNDERWATER_SILVER_RUPEE_CHEST,
          lambda bundle: can_use(Items.HOOKSHOT, bundle) and can_use(Items.SONG_OF_TIME, bundle) and can_use(
-             Items.IRON_BOOTS, bundle) and water_timer(bundle) >= 24),
+             Items.IRON_BOOTS, bundle) and water_timer(bundle) >= 24 and has_item(Items.BRONZE_SCALE)),
     ])
     # Connections
     connect_regions(Regions.GERUDO_TRAINING_GROUND_LAVA_ROOM, world, [

--- a/worlds/oot_soh/location_access/dungeons/shadow_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/shadow_temple.py
@@ -93,7 +93,7 @@ def set_region_rules(world: "SohWorld") -> None:
         (Locations.SHADOW_TEMPLE_GS_FALLING_SPIKES_ROOM, lambda bundle: can_use(Items.HOOKSHOT, bundle) or (can_do_trick(Tricks.SHADOW_UMBRELLA_GS, bundle) and can_use(
             Items.HOVER_BOOTS, bundle) and can_standing_shield(bundle) and can_use(Items.MASTER_SWORD, bundle)) or (is_adult(bundle) and can_ground_jump(bundle))),
         (Locations.SHADOW_TEMPLE_GS_SINGLE_GIANT_POT, lambda bundle: small_keys(Items.SHADOW_TEMPLE_SMALL_KEY, 2, bundle) and ((can_do_trick(
-            Tricks.LENS_SHADOW_PLATFORM, bundle) and can_do_trick(Tricks.LENS_SHADOW, bundle)) or can_use(Items.LENS_OF_TRUTH, bundle) and can_use(Items.HOOKSHOT, bundle))),
+            Tricks.LENS_SHADOW_PLATFORM, bundle) and can_do_trick(Tricks.LENS_SHADOW, bundle)) or can_use(Items.LENS_OF_TRUTH, bundle)) and can_use(Items.HOOKSHOT, bundle)),
         (Locations.SHADOW_TEMPLE_FALLING_SPIKES_POT1,
          lambda bundle: can_break_pots(bundle)),
         (Locations.SHADOW_TEMPLE_FALLING_SPIKES_POT2,


### PR DESCRIPTION
The single giant pot GS in Shadow Temple access rule was written in such a way to where if you have the Lens Shadow tricks on, it would not require Hookshot to access it. I reordered the parentheses in a way that should fix it, but feel free to double check it
