### PR TITLE
Fix Client reconnect loop

### DIFF
--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -127,6 +127,7 @@ class Regions(StrEnum):
     CASTLE_GROUNDS_FROM_GANONS_CASTLE = "Castle Grounds From Ganon's Castle"
     HYRULE_CASTLE_GROUNDS = "Hyrule Castle Grounds"
     HC_GARDEN_SONG_FROM_IMPA = "HC Garden Song From Impa"
+    HC_GARDEN_ZELDAS_LETTER = "HC Garden Zelda's Letter"
     HC_GARDEN = "HC Garden"
     HC_GREAT_FAIRY_FOUNTAIN = "HC Great Fairy Fountain"
     HC_STORMS_GROTTO = "HC Storms Grotto"

--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -126,8 +126,6 @@ class Regions(StrEnum):
     CASTLE_GROUNDS = "Castle Grounds"
     CASTLE_GROUNDS_FROM_GANONS_CASTLE = "Castle Grounds From Ganon's Castle"
     HYRULE_CASTLE_GROUNDS = "Hyrule Castle Grounds"
-    HC_GARDEN_SONG_FROM_IMPA = "HC Garden Song From Impa"
-    HC_GARDEN_ZELDAS_LETTER = "HC Garden Zelda's Letter"
     HC_GARDEN = "HC Garden"
     HC_GREAT_FAIRY_FOUNTAIN = "HC Great Fairy Fountain"
     HC_STORMS_GROTTO = "HC Storms Grotto"

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -407,13 +407,15 @@ def place_locked_items(world: "SohWorld") -> None:
     if world.options.start_with_links_pocket == "advancement":
         world.get_location(Locations.LINKS_POCKET).progress_type = LocationProgressType.PRIORITY
 
-    # Add Weird Egg and Zelda's Letter to their vanilla locations when not shuffled
-    place_locked_item(Locations.HC_ZELDAS_LETTER, Items.ZELDAS_LETTER, world)
+    # If not skip_child_zelda, connect Malon Egg loc to root
     if not world.options.skip_child_zelda:
-        convert_to_event(Locations.HC_ZELDAS_LETTER)
+        connect_to_root(Locations.HC_MALON_EGG, world)
+        # If not skip_child_zelda and not shuffle_weird_egg, place the weird egg
         if not world.options.shuffle_weird_egg:
             place_locked_item(Locations.HC_MALON_EGG, Items.WEIRD_EGG, world)
-            convert_to_event(Locations.HC_MALON_EGG, world)
+
+    # Zeldas Letter always gets placed to it's location
+    place_locked_item(Locations.HC_ZELDAS_LETTER, Items.ZELDAS_LETTER, world)
         
     if world.options.shuffle_songs == "off":
         for location, song in song_vanilla_locations.items():
@@ -516,16 +518,13 @@ def place_locked_items(world: "SohWorld") -> None:
         for location, item in map_and_compass_vanilla_mapping.items():
             place_locked_item(location, item, world)
 
-def convert_to_event(location: Locations, world: "SohWorld"):
-    # Make Event
+def connect_to_root(location: Locations, world: "SohWorld"):
     loc = world.get_location(location)
-    loc.address = None
-    loc.item.code = None
 
     # Connect to Root if not already
     region = loc.parent_region
     root = world.get_region(Regions.ROOT)
     if region != root:
         region.locations.remove(loc)
-        loc.parent_region= root
+        loc.parent_region = root
         root.locations.append(loc)

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -408,10 +408,12 @@ def place_locked_items(world: "SohWorld") -> None:
         world.get_location(Locations.LINKS_POCKET).progress_type = LocationProgressType.PRIORITY
 
     # Add Weird Egg and Zelda's Letter to their vanilla locations when not shuffled
-    if not world.options.skip_child_zelda and not world.options.shuffle_weird_egg:
-        place_locked_item(Locations.HC_MALON_EGG, Items.WEIRD_EGG, world)
-
     place_locked_item(Locations.HC_ZELDAS_LETTER, Items.ZELDAS_LETTER, world)
+    if not world.options.skip_child_zelda:
+        convert_to_event(Locations.HC_ZELDAS_LETTER)
+        if not world.options.shuffle_weird_egg:
+            place_locked_item(Locations.HC_MALON_EGG, Items.WEIRD_EGG, world)
+            convert_to_event(Locations.HC_MALON_EGG, world)
         
     if world.options.shuffle_songs == "off":
         for location, song in song_vanilla_locations.items():
@@ -513,3 +515,17 @@ def place_locked_items(world: "SohWorld") -> None:
     if world.options.maps_and_compasses == "vanilla":
         for location, item in map_and_compass_vanilla_mapping.items():
             place_locked_item(location, item, world)
+
+def convert_to_event(location: Locations, world: "SohWorld"):
+    # Make Event
+    loc = world.get_location(location)
+    loc.address = None
+    loc.item.code = None
+
+    # Connect to Root if not already
+    region = loc.parent_region
+    root = world.get_region(Regions.ROOT)
+    if region != root:
+        region.locations.remove(loc)
+        loc.parent_region= root
+        root.locations.append(loc)

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -403,7 +403,7 @@ def place_locked_items(world: "SohWorld") -> None:
     if world.options.start_with_links_pocket == "advancement":
         world.get_location(Locations.LINKS_POCKET).progress_type = LocationProgressType.PRIORITY
 
-    # If not skip_child_zelda, connect the locations to root
+    # If skip_child_zelda, connect the locations to root
     if not world.options.skip_child_zelda:
         # If not skip_child_zelda and not shuffle_weird_egg, place the weird egg
         if not world.options.shuffle_weird_egg:

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -412,7 +412,7 @@ def place_locked_items(world: "SohWorld") -> None:
         connect_to_root(Locations.HC_MALON_EGG, world)
         connect_to_root(Locations.HC_ZELDAS_LETTER, world)
         connect_to_root(Locations.SONG_FROM_IMPA, world)
-    
+        world.multiworld.regions.region_cache[world.player].pop(Regions.HC_GARDEN)
 
     # Zeldas Letter always gets placed to it's location
     place_locked_item(Locations.HC_ZELDAS_LETTER, Items.ZELDAS_LETTER, world)

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -112,9 +112,6 @@ def create_regions_and_locations(world: "SohWorld") -> None:
         region_data_table[entry] = SohRegionData([])
 
     # exclusions
-    # We don't need HC Garden if child zelda is skipped
-    if world.options.skip_child_zelda:
-        region_data_table.pop(Regions.HC_GARDEN)
 
     # Create regions.
     for region_name in region_data_table.keys():
@@ -234,7 +231,6 @@ def create_regions_and_locations(world: "SohWorld") -> None:
         world.included_locations.update(links_pocket_location_table)
 
     # Child Zelda
-    # if not world.options.skip_child_zelda:
     world.included_locations.update(child_zelda_location_table)
 
     # Carpenters
@@ -407,12 +403,16 @@ def place_locked_items(world: "SohWorld") -> None:
     if world.options.start_with_links_pocket == "advancement":
         world.get_location(Locations.LINKS_POCKET).progress_type = LocationProgressType.PRIORITY
 
-    # If not skip_child_zelda, connect Malon Egg loc to root
+    # If not skip_child_zelda, connect the locations to root
     if not world.options.skip_child_zelda:
-        connect_to_root(Locations.HC_MALON_EGG, world)
         # If not skip_child_zelda and not shuffle_weird_egg, place the weird egg
         if not world.options.shuffle_weird_egg:
             place_locked_item(Locations.HC_MALON_EGG, Items.WEIRD_EGG, world)
+    else:
+        connect_to_root(Locations.HC_MALON_EGG, world)
+        connect_to_root(Locations.HC_ZELDAS_LETTER, world)
+        connect_to_root(Locations.SONG_FROM_IMPA, world)
+    
 
     # Zeldas Letter always gets placed to it's location
     place_locked_item(Locations.HC_ZELDAS_LETTER, Items.ZELDAS_LETTER, world)

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -234,8 +234,8 @@ def create_regions_and_locations(world: "SohWorld") -> None:
         world.included_locations.update(links_pocket_location_table)
 
     # Child Zelda
-    if not world.options.skip_child_zelda:
-        world.included_locations.update(child_zelda_location_table)
+    # if not world.options.skip_child_zelda:
+    world.included_locations.update(child_zelda_location_table)
 
     # Carpenters
     if world.options.fortress_carpenters == "normal":
@@ -411,8 +411,7 @@ def place_locked_items(world: "SohWorld") -> None:
     if not world.options.skip_child_zelda and not world.options.shuffle_weird_egg:
         place_locked_item(Locations.HC_MALON_EGG, Items.WEIRD_EGG, world)
 
-    if not world.options.skip_child_zelda:
-        place_locked_item(Locations.HC_ZELDAS_LETTER, Items.ZELDAS_LETTER, world)
+    place_locked_item(Locations.HC_ZELDAS_LETTER, Items.ZELDAS_LETTER, world)
         
     if world.options.shuffle_songs == "off":
         for location, song in song_vanilla_locations.items():

--- a/worlds/oot_soh/location_access/overworld/castle_grounds.py
+++ b/worlds/oot_soh/location_access/overworld/castle_grounds.py
@@ -81,14 +81,17 @@ def set_region_rules(world: "SohWorld") -> None:
     # Hyrule Castle Garden
     # Locations
     if not world.options.skip_child_zelda:
-        add_locations(Regions.HC_GARDEN, world, [
-            (Locations.HC_ZELDAS_LETTER, lambda bundle: True_())
-        ])
         # Connections
         connect_regions(Regions.HC_GARDEN, world, [
             (Regions.HYRULE_CASTLE_GROUNDS, lambda bundle: True_()),
+            (Regions.HC_GARDEN_ZELDAS_LETTER, lambda bundle: True_()),
             (Regions.HC_GARDEN_SONG_FROM_IMPA, lambda bundle: True_())
         ])
+
+    # Hyrule Castle Garden Zeldas Letter
+    add_locations(Regions.HC_GARDEN_ZELDAS_LETTER, world, [
+        (Locations.HC_ZELDAS_LETTER, lambda bundle: True_())
+    ])
 
     # Hyrule Castle Garden Song From Impa
     add_locations(Regions.HC_GARDEN_SONG_FROM_IMPA, world, [

--- a/worlds/oot_soh/location_access/overworld/castle_grounds.py
+++ b/worlds/oot_soh/location_access/overworld/castle_grounds.py
@@ -80,23 +80,16 @@ def set_region_rules(world: "SohWorld") -> None:
 
     # Hyrule Castle Garden
     # Locations
+    add_locations(Regions.HC_GARDEN, world, [
+        (Locations.HC_ZELDAS_LETTER, lambda bundle: True_()),
+        (Locations.SONG_FROM_IMPA, lambda bundle: True_())
+
+    ])
     if not world.options.skip_child_zelda:
         # Connections
         connect_regions(Regions.HC_GARDEN, world, [
             (Regions.HYRULE_CASTLE_GROUNDS, lambda bundle: True_()),
-            (Regions.HC_GARDEN_ZELDAS_LETTER, lambda bundle: True_()),
-            (Regions.HC_GARDEN_SONG_FROM_IMPA, lambda bundle: True_())
         ])
-
-    # Hyrule Castle Garden Zeldas Letter
-    add_locations(Regions.HC_GARDEN_ZELDAS_LETTER, world, [
-        (Locations.HC_ZELDAS_LETTER, lambda bundle: True_())
-    ])
-
-    # Hyrule Castle Garden Song From Impa
-    add_locations(Regions.HC_GARDEN_SONG_FROM_IMPA, world, [
-        (Locations.SONG_FROM_IMPA, lambda bundle: True_())
-    ])
 
     # Hyrule Castle Great Fairy Fountain
     # Locations

--- a/worlds/oot_soh/location_access/root.py
+++ b/worlds/oot_soh/location_access/root.py
@@ -29,14 +29,6 @@ def set_region_rules(world: "SohWorld") -> None:
             bundle) | has_item(Events.TIME_TRAVEL, bundle))
     ])
 
-    # Connection for Zeldas Letter/Impas Song
-    if (bool(world.options.skip_child_zelda)):
-        # Connections
-        connect_regions(Regions.ROOT, world, [
-            (Regions.HC_GARDEN_ZELDAS_LETTER, lambda bundle: True_()),
-            (Regions.HC_GARDEN_SONG_FROM_IMPA, lambda bundle: True_())
-        ])
-
     # Connection for Master Sword as you start with it when starting age is adult and MS is not shuffled.
     if (world.options.starting_age == "adult" and not world.options.shuffle_master_sword):
         # Connections

--- a/worlds/oot_soh/location_access/root.py
+++ b/worlds/oot_soh/location_access/root.py
@@ -29,15 +29,11 @@ def set_region_rules(world: "SohWorld") -> None:
             bundle) | has_item(Events.TIME_TRAVEL, bundle))
     ])
 
-    # Event and connection for Zeldas Letter/Impas Song
+    # Connection for Zeldas Letter/Impas Song
     if (bool(world.options.skip_child_zelda)):
-        # Events
-        add_events(Regions.ROOT, world, [
-            (EventLocations.ZELDAS_LETTER_FROM_SKIP_OPTION,
-             Items.ZELDAS_LETTER, lambda bundle: True_())
-        ])
         # Connections
         connect_regions(Regions.ROOT, world, [
+            (Regions.HC_GARDEN_ZELDAS_LETTER, lambda bundle: True_()),
             (Regions.HC_GARDEN_SONG_FROM_IMPA, lambda bundle: True_())
         ])
 


### PR DESCRIPTION
The issue is that the client is trying to do things with these two locations (ID 61 and 62) even when they aren't supposed to be created when the `skip_child_zelda` option is true.

So my solution is to always make these locations, just connect them to the root regions after the fact if that is where they should be.