### PR TITLE
oot_soh: Fix wrong shuffle_ocarina slot data for UT

### DIFF
--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -460,7 +460,7 @@ class SohWorld(World):
             "shuffle_master_sword": self.options.shuffle_master_sword.value,
             "shuffle_childs_wallet": self.options.shuffle_childs_wallet.value,
             "shuffle_tycoon_wallet": self.options.shuffle_tycoon_wallet.value,
-            "shuffle_ocarinas": self.options.shuffle_ocarina_buttons.value,
+            "shuffle_ocarinas": self.options.shuffle_ocarinas.value,
             "shuffle_ocarina_buttons": self.options.shuffle_ocarina_buttons.value,
             "shuffle_swim": self.options.shuffle_swim.value,
             "shuffle_gerudo_membership_card": self.options.shuffle_gerudo_membership_card.value,


### PR DESCRIPTION
Reported by Evil God on Discord (see #232). Fixes UT support edge case when starting age is adult, door of time is closed but rewards, ocarinas and songs are shuffled everywhere (but not ocarina buttons), UT won't set the shuffled ocarinas option correctly (setting to be unshuffled) so the option adjustment forces child.

Manually tested the change. Needs seed re-gen.