### PR TITLE
RB: Fix Deku Tree Basement Back Room Connection

### DIFF
--- a/worlds/oot_soh/location_access/dungeons/deku_tree.py
+++ b/worlds/oot_soh/location_access/dungeons/deku_tree.py
@@ -222,7 +222,7 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.DEKU_TREE_BASEMENT_BACK_LOBBY, world, [
         (Regions.DEKU_TREE_BASEMENT_TORCH_ROOM, lambda bundle: True_() ),
         (Regions.DEKU_TREE_BASEMENT_BACK_ROOM, lambda bundle: (
-            has_fire_source_with_torch(bundle) | can_use(Items.FAIRY_BOW, bundle))),
+            has_fire_source_with_torch(bundle) | can_use(Items.FAIRY_BOW, bundle)) & blast_or_smash(bundle)),
         (Regions.DEKU_TREE_BASEMENT_UPPER, lambda bundle: (
             has_fire_source_with_torch(bundle) | can_use(Items.FAIRY_BOW, bundle))),
     ])


### PR DESCRIPTION
Closes #227, as this region connection was missing a `blast_or_smash` requirement.