### PR TITLE
Slight Speed bump to prefill

### DIFF
--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -349,15 +349,11 @@ class SohWorld(World):
             prefill_state = self.get_pre_fill_state()
 
         # get empty, non reserved locations
-        # adding this extra makes it so we have to loop less if fill overflows and there are more locations and items to try placing
-        extra = 100
         empty_locations_all = self.get_empty_locations_from_list_shuffled(locations)
-        count_empty_locations_all = len(empty_locations_all) + extra
+        count_empty_locations_all = len(empty_locations_all)
         # slice the list so that there aren't as many for fill_restrictive to choose from. Helps performance
-        # give it the same amount of locations as there are items plus extra
-        chunk = len(item_pool) + extra
-        last_end = chunk
-        empty_locations = empty_locations_all[0:last_end]
+        chunk = min(len(item_pool) + 100, count_empty_locations_all)
+        empty_locations = empty_locations_all[:chunk] if chunk != count_empty_locations_all else empty_locations_all
         items = [self.create_item(str(item)) for item in item_pool]
         self.preplaced_items.extend(items)
 
@@ -378,15 +374,14 @@ class SohWorld(World):
         else:
             fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
 
-            # Check if any items and locations are left. If so try again until we run out of either.
-            while len(items) > 0 and last_end < count_empty_locations_all:
-                fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
-
-                empty_locations = empty_locations_all[last_end: chunk]
-                last_end += chunk
+            # Check if any items and locations are left. If so try again once more with the rest of the locations
+            if len(items) > 0 and chunk != count_empty_locations_all:
+                empty_locations = empty_locations_all[chunk:]
 
                 if original_goal is None:
                     self.multiworld.completion_condition[self.player] = create_new_goal(empty_locations) 
+
+                fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
             
             # Add any unplaced items to the item pool
             self.add_items_to_item_pool_list(items)

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -354,7 +354,7 @@ class SohWorld(World):
         empty_locations_all = self.get_empty_locations_from_list_shuffled(locations)
         count_empty_locations_all = len(empty_locations_all) + extra
         # slice the list so that there aren't as many for fill_restrictive to choose from. Helps performance
-        # give it the same amount of locations as there are items
+        # give it the same amount of locations as there are items plus extra
         chunk = len(item_pool) + extra
         last_end = chunk
         empty_locations = empty_locations_all[0:last_end]

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -347,18 +347,21 @@ class SohWorld(World):
                     self.pre_fill_pool.remove(item)
             
             prefill_state = self.get_pre_fill_state()
-        
-        if goal is None:
-            # set region accessability of locations as the goal
-            accessibility_goal = {self.get_location(loc) for loc in locations}
-            goal = lambda state: all([state.can_reach(reg) for reg in accessibility_goal])
-
-        self.multiworld.completion_condition[self.player] = goal
 
         # get empty, non reserved locations
         empty_locations = self.get_empty_locations_from_list_shuffled(locations)
+        # slice the list so that there aren't as many for fill_restrictive to choose from. Helps performance
+        # give it the amount of items plus 100 (or till the end if it is less than 100) 
+        empty_locations = empty_locations[0:len(item_pool) + 100]
         items = [self.create_item(str(item)) for item in item_pool]
         self.preplaced_items.extend(items)
+        
+        if goal is None:
+            # set region accessability of locations as the goal
+            accessibility_goal = {loc for loc in empty_locations}
+            goal = lambda state: all([state.can_reach(reg) for reg in accessibility_goal])
+
+        self.multiworld.completion_condition[self.player] = goal
 
         if self.settings.disable_fill_overflow:
             fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True)
@@ -366,7 +369,7 @@ class SohWorld(World):
             # Add any unplaced items to the item pool
             fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
             self.add_items_to_item_pool_list(items)
-        
+
         for item in items:
             self.preplaced_items.remove(item)
 

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -339,7 +339,7 @@ class SohWorld(World):
         for hint in hints:
             self.static_hints.update(hint.serialize())
             
-    def run_prefill(self, item_pool: list[Items], locations: list[Locations], prefill_state: CollectionState | None = None, goal: Callable[[CollectionState], bool] | None = None):
+    def run_prefill(self, item_pool: list[Items], locations: list[Locations], prefill_state: CollectionState | None = None, original_goal: Callable[[CollectionState], bool] | None = None):
         # check if we're using specific collectionstate
         if prefill_state is None:
             for item in item_pool:
@@ -349,25 +349,46 @@ class SohWorld(World):
             prefill_state = self.get_pre_fill_state()
 
         # get empty, non reserved locations
-        empty_locations = self.get_empty_locations_from_list_shuffled(locations)
+        # adding this extra makes it so we have to loop less if fill overflows and there are more locations and items to try placing
+        extra = 100
+        empty_locations_all = self.get_empty_locations_from_list_shuffled(locations)
+        count_empty_locations_all = len(empty_locations_all) + extra
         # slice the list so that there aren't as many for fill_restrictive to choose from. Helps performance
-        # give it the amount of items plus 100 (or till the end if it is less than 100) 
-        empty_locations = empty_locations[0:len(item_pool) + 100]
+        # give it the same amount of locations as there are items
+        chunk = len(item_pool) + extra
+        last_end = chunk
+        empty_locations = empty_locations_all[0:last_end]
         items = [self.create_item(str(item)) for item in item_pool]
         self.preplaced_items.extend(items)
+
+        def create_new_goal(empty_locations: list[Location]):
+            goal = lambda state: all([state.can_reach(loc) for loc in empty_locations])
+            return goal
         
-        if goal is None:
+        if original_goal is None:
             # set region accessability of locations as the goal
-            accessibility_goal = {loc for loc in empty_locations}
-            goal = lambda state: all([state.can_reach(reg) for reg in accessibility_goal])
+            goal = create_new_goal(empty_locations)
+        else:
+            goal = original_goal
 
         self.multiworld.completion_condition[self.player] = goal
 
         if self.settings.disable_fill_overflow:
             fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True)
         else:
-            # Add any unplaced items to the item pool
             fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
+
+            # Check if any items and locations are left. If so try again until we run out of either.
+            while len(items) > 0 and last_end < count_empty_locations_all:
+                fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
+
+                empty_locations = empty_locations_all[last_end: chunk]
+                last_end += chunk
+
+                if original_goal is None:
+                    self.multiworld.completion_condition[self.player] = create_new_goal(empty_locations) 
+            
+            # Add any unplaced items to the item pool
             self.add_items_to_item_pool_list(items)
 
         for item in items:

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -340,6 +340,10 @@ class SohWorld(World):
             self.static_hints.update(hint.serialize())
             
     def run_prefill(self, item_pool: list[Items], locations: list[Locations], prefill_state: CollectionState | None = None, original_goal: Callable[[CollectionState], bool] | None = None):
+        def create_new_goal(empty_locations: list[Location]):
+            goal = lambda state: all([state.can_reach(loc) for loc in empty_locations])
+            return goal
+        
         # check if we're using specific collectionstate
         if prefill_state is None:
             for item in item_pool:
@@ -351,15 +355,16 @@ class SohWorld(World):
         # get empty, non reserved locations
         empty_locations_all = self.get_empty_locations_from_list_shuffled(locations)
         count_empty_locations_all = len(empty_locations_all)
-        # slice the list so that there aren't as many for fill_restrictive to choose from. Helps performance
         chunk = min(len(item_pool) + 100, count_empty_locations_all)
-        empty_locations = empty_locations_all[:chunk] if chunk != count_empty_locations_all else empty_locations_all
+
+        # If fill overflow is disabled or the chunk is as large as the original list, use all locations
+        if self.settings.disable_fill_overflow or chunk == count_empty_locations_all:
+            empty_locations = empty_locations_all
+        else:
+            empty_locations = empty_locations_all[:chunk]
+
         items = [self.create_item(str(item)) for item in item_pool]
         self.preplaced_items.extend(items)
-
-        def create_new_goal(empty_locations: list[Location]):
-            goal = lambda state: all([state.can_reach(loc) for loc in empty_locations])
-            return goal
         
         if original_goal is None:
             # set region accessability of locations as the goal
@@ -369,22 +374,20 @@ class SohWorld(World):
 
         self.multiworld.completion_condition[self.player] = goal
 
-        if self.settings.disable_fill_overflow:
-            fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True)
-        else:
+        # Determines if a partial or full fill is occuring
+        fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=(not self.settings.disable_fill_overflow))
+
+        # Check if any items and locations are left. If so try again once more with the rest of the locations
+        if len(items) > 0 and chunk != count_empty_locations_all:
+            empty_locations = empty_locations_all[chunk:]
+
+            if original_goal is None:
+                self.multiworld.completion_condition[self.player] = create_new_goal(empty_locations) 
+
             fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
-
-            # Check if any items and locations are left. If so try again once more with the rest of the locations
-            if len(items) > 0 and chunk != count_empty_locations_all:
-                empty_locations = empty_locations_all[chunk:]
-
-                if original_goal is None:
-                    self.multiworld.completion_condition[self.player] = create_new_goal(empty_locations) 
-
-                fill_restrictive(self.multiworld, prefill_state, empty_locations, items, single_player_placement=True, lock=True, allow_partial=True)
-            
-            # Add any unplaced items to the item pool
-            self.add_items_to_item_pool_list(items)
+        
+        # Add any unplaced items to the item pool
+        self.add_items_to_item_pool_list(items)
 
         for item in items:
             self.preplaced_items.remove(item)


### PR DESCRIPTION
Limit the number of locations we set as a goal (add give to fill_restrictive) while prefilling.

In practice, every prefill except for overworld and maybe any dungeon should get the same result. 

For those two, this will just mean we will take the random list of available locations and slice it from the beginning to the length of the item pool plus some extra for swap space.