### PR TITLE
More complex time of day checking

### DIFF
--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -3954,3 +3954,9 @@ class HintKeys(StrEnum):
     KAK_50_SKULLS_HINT = "50 Skulls Hint"
     KAK_100_SKULLS_HINT = "100 Skulls Hint"
     MASK_SHOP_HINT = "Mask Shop Hint"
+
+class TimeOfDay(IntEnum):
+    NONE = auto()
+    DAY = auto()
+    NIGHT = auto()
+    ALL = DAY | NIGHT

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -334,16 +334,26 @@ def is_adult(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     return state._soh_can_reach_as_age(parent_region, Ages.ADULT, world.player)  # type: ignore # noqa
 
 
+# TODO: Implement starting time of day if that ever gets added
 def at_day(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
-    return ((is_child(bundle) and has_item(Events.CHILD_CAN_PASS_TIME, bundle))
-            or (is_adult(bundle) and has_item(Events.ADULT_CAN_PASS_TIME, bundle)))
-    # TODO: Implement starting time of day if that ever gets added
+    condition = can_use(Items.SUNS_SONG, bundle)
+    if bundle[2].complex_tod_checking:
+        condition = condition or bundle[0]._soh_reach_at_time(str(bundle[1]), TimeOfDay.DAY, [], bundle[2].player)
+    else:
+        condition = condition or ((is_child(bundle) and has_item(Events.CHILD_CAN_PASS_TIME, bundle)) or (is_adult(bundle) and has_item(Events.ADULT_CAN_PASS_TIME, bundle)))
+    
+    return condition
 
 
+# TODO: Implement starting time of day if that ever gets added
 def at_night(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
-    return ((is_child(bundle) and has_item(Events.CHILD_CAN_PASS_TIME, bundle))
-            or (is_adult(bundle) and has_item(Events.ADULT_CAN_PASS_TIME, bundle)))
-    # TODO: Implement starting time of day if that ever gets added
+    condition = can_use(Items.SUNS_SONG, bundle)
+    if bundle[2].complex_tod_checking:
+        condition = condition or bundle[0]._soh_reach_at_time(str(bundle[1]), TimeOfDay.NIGHT, [], bundle[2].player)
+    else:
+        condition = condition or ((is_child(bundle) and has_item(Events.CHILD_CAN_PASS_TIME, bundle)) or (is_adult(bundle) and has_item(Events.ADULT_CAN_PASS_TIME, bundle)))
+
+    return condition
 
 
 def is_child(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:

--- a/worlds/oot_soh/RegionAgeAccess.py
+++ b/worlds/oot_soh/RegionAgeAccess.py
@@ -1,7 +1,8 @@
 from collections import deque
+from collections.abc import Iterable
 from BaseClasses import CollectionState, MultiWorld
 from worlds.AutoWorld import LogicMixin
-from .Enums import Regions, Ages
+from .Enums import Regions, Ages, TimeOfDay
 import copy
 
 
@@ -17,6 +18,8 @@ class SohAgeLogic(LogicMixin):
             player: set() for player in players}
         self._soh_child_blocked_regions = {player: set() for player in players}
         self._soh_adult_blocked_regions = {player: set() for player in players}
+        self._soh_day_reachable_regions = {player: set() for player in players}
+        self._soh_night_reachable_regions = {player: set() for player in players}
         self._soh_age = {player: Ages.null for player in players}
 
     def copy_mixin(self, ret) -> CollectionState:
@@ -30,6 +33,10 @@ class SohAgeLogic(LogicMixin):
             regions) for player, regions in self._soh_child_blocked_regions.items()}
         ret._soh_adult_blocked_regions = {player: copy.copy(
             regions) for player, regions in self._soh_adult_blocked_regions.items()}
+        ret._soh_day_reachable_regions = {player: copy.copy(
+            regions) for player, regions in self._soh_day_reachable_regions.items()}
+        ret._soh_night_reachable_regions = {player: copy.copy(
+            regions) for player, regions in self._soh_night_reachable_regions.items()}
         ret._soh_age = {player: age for player, age in self._soh_age.items()}
         return ret
 
@@ -38,6 +45,8 @@ class SohAgeLogic(LogicMixin):
         self._soh_adult_reachable_regions[player] = set()
         self._soh_child_blocked_regions[player] = set()
         self._soh_adult_blocked_regions[player] = set()
+        self._soh_day_reachable_regions[player] = set()
+        self._soh_night_reachable_regions[player] = set()
         self._soh_stale[player] = True
 
     def _soh_update_age_reachable_regions(self, player):
@@ -87,3 +96,33 @@ class SohAgeLogic(LogicMixin):
             self._soh_age[player] = Ages.null
             return can_reach
         return self._soh_age[player] == age
+    
+    def _soh_reach_at_time(self, regionname: str, tod: TimeOfDay, already_checked: list[str], player: int):
+        name_map = {
+            TimeOfDay.DAY: self._soh_day_reachable_regions[player],
+            TimeOfDay.NIGHT: self._soh_night_reachable_regions[player],
+            TimeOfDay.ALL: self._soh_day_reachable_regions[player].intersection(self._soh_night_reachable_regions[player])
+        }
+        if regionname in name_map[tod]:
+            return True
+        region = self.multiworld.get_region(regionname, player)
+        if region.provides_time == TimeOfDay.ALL or regionname == str(Regions.ROOT):
+            self._soh_day_reachable_regions[player].add(regionname)
+            self._soh_night_reachable_regions[player].add(regionname)
+            return True
+        if region.provides_time == TimeOfDay.NIGHT:
+            self._soh_night_reachable_regions[player].add(regionname)
+            return tod == TimeOfDay.NIGHT
+        for entrance in region.entrances:
+            if entrance.parent_region.name in already_checked:
+                continue
+            if self._soh_reach_at_time(entrance.parent_region.name, tod, already_checked + [regionname], player):
+                if tod == TimeOfDay.DAY:
+                    self._soh_day_reachable_regions[player].add(regionname)
+                elif tod == TimeOfDay.NIGHT:
+                    self._soh_night_reachable_regions[player].add(regionname)
+                elif tod == TimeOfDay.ALL:
+                    self._soh_day_reachable_regions[player].add(regionname)
+                    self._soh_night_reachable_regions[player].add(regionname)
+                return True
+        return False

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple, TYPE_CHECKING
 from worlds.AutoWorld import LogicMixin
 from BaseClasses import MultiWorld, Region, ItemClassification, LocationProgressType
+from .LogicHelpers import add_events, is_child, is_adult
 from .Enums import *
 from .Locations import SohLocation, base_location_table, \
     gold_skulltula_overworld_location_table, \
@@ -89,6 +90,7 @@ class SohRegion(Region):
 
     def __init__(self, name: str, player: int, multiworld: MultiWorld, hint: str | None = None):
         super().__init__(name, player, multiworld, hint)
+        self.provides_time = TimeOfDay.NONE
 
     def can_reach(self, state) -> bool:
         if state._soh_stale[self.player]:
@@ -118,6 +120,35 @@ def create_regions_and_locations(world: "SohWorld") -> None:
         region = SohRegion(region_name, world.player, world.multiworld)
         world.multiworld.regions.append(region)
         region.add_exits(region_data_table[region_name].connecting_regions)
+
+    if world.complex_tod_checking:
+        # Set regions where time passes
+        for regions in (Regions.HYRULE_FIELD, Regions.LAKE_HYLIA, Regions.GERUDO_VALLEY, Regions.GV_UPPER_STREAM, Regions.GV_LOWER_STREAM, 
+                        Regions.GV_CRATE_LEDGE, Regions.GV_GROTTO_LEDGE, Regions.GV_FORTRESS_SIDE, Regions.DESERT_COLOSSUS, Regions.SPIRIT_TEMPLE_OUTDOOR_HANDS, 
+                        Regions.HYRULE_CASTLE_GROUNDS, Regions.DEATH_MOUNTAIN_TRAIL, Regions.DEATH_MOUNTAIN_SUMMIT, Regions.ZR_FRONT, Regions.ZORA_RIVER):
+            world.get_region(str(regions)).provides_time = TimeOfDay.ALL
+
+        # OGC Night Time
+        world.get_region(str(Regions.GANONS_CASTLE_GROUNDS)).provides_time = TimeOfDay.NIGHT
+    else:
+        # Create events for regions where time passes both
+        for regions in (Regions.HYRULE_FIELD, Regions.LAKE_HYLIA, Regions.GERUDO_VALLEY, Regions.GV_UPPER_STREAM, Regions.GV_LOWER_STREAM, 
+                        Regions.GV_CRATE_LEDGE, Regions.GV_GROTTO_LEDGE, Regions.DESERT_COLOSSUS, Regions.SPIRIT_TEMPLE_OUTDOOR_HANDS, 
+                        Regions.DEATH_MOUNTAIN_TRAIL, Regions.DEATH_MOUNTAIN_SUMMIT, Regions.ZR_FRONT, Regions.ZORA_RIVER):
+            add_events(regions, world, [
+                (str(regions) + " Day Night Cycle Child", Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
+                (str(regions) + " Day Night Cycle Adult", Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle))
+            ])
+
+        # Adult only
+        add_events(Regions.GV_FORTRESS_SIDE, world, [
+            (str(Regions.GV_FORTRESS_SIDE) + " Day Night Cycle Adult", Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle))
+        ])
+
+        # Child only
+        add_events(Regions.HYRULE_CASTLE_GROUNDS, world, [
+            (str(Regions.HYRULE_CASTLE_GROUNDS) + " Day Night Cycle Child", Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle))
+        ])
 
     # Create locations
 

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -123,6 +123,7 @@ class SohWorld(World):
         self.pre_fill_pool = list[Items]()
         self.reserved_pre_fill_locations = list[Locations]()
         self.static_hints = dict[str, list[list[int, int]]]()
+        self.complex_tod_checking = False
 
         apworld_manifest = orjson.loads(pkgutil.get_data(
             __name__, "archipelago.json").decode("utf-8"))

--- a/worlds/oot_soh/location_access/overworld/castle_grounds.py
+++ b/worlds/oot_soh/location_access/overworld/castle_grounds.py
@@ -12,7 +12,6 @@ class EventLocations(StrEnum):
     HC_STORMS_GROTTO_BEHIND_WALLS_GOSSIP_STONE_SONG_FAIRY = "HC Storms Grotto Behind Walls Gossip Stone Song Fairy"
     HC_STORMS_GROTTO_BEHIND_WALLS_WANDERING_BUGS = "HC Storms Grotto Behind Walls Wandering Bugs"
     HC_OGC_RAINBOW_BRIDGE = "HC OGC Rainbow Bridge"
-    HC_DAY_NIGHT_CYCLE_CHILD = "HC Day Night Cycle Child"
 
 
 class LocalEvents(StrEnum):
@@ -35,9 +34,7 @@ def set_region_rules(world: "SohWorld") -> None:
          lambda bundle: call_gossip_fairy(bundle)),
         (EventLocations.HC_BUTTERFLY_FAIRY, Events.CAN_ACCESS_FAIRIES,
          lambda bundle: can_use(Items.STICKS, bundle)),
-        (EventLocations.HC_BUG_ROCK, Events.CAN_ACCESS_BUGS, lambda bundle: True),
-        (EventLocations.HC_DAY_NIGHT_CYCLE_CHILD,
-         Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
+        (EventLocations.HC_BUG_ROCK, Events.CAN_ACCESS_BUGS, lambda bundle: True)
     ])
     # Locations
     add_locations(Regions.HYRULE_CASTLE_GROUNDS, world, [

--- a/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
@@ -13,8 +13,6 @@ class EventLocations(StrEnum):
     DMT_STORMS_GROTTO_BUG_GRASS = "DMT Storms Grotto Bug Grass"
     DMT_STORMS_GROTTO_PUDDLE_FISH = "DMT Storms Grotto Puddle Fish"
     DMT_BEAN_PATCH = "DMT Bean Patch"
-    DMT_DAY_NIGHT_CYCLE_CHILD = "DMT Day Night Cycle Child"
-    DMT_DAY_NIGHT_CYCLE_ADULT = "DMT Day Night Cycle Adult"
 
 
 class LocalEvents(StrEnum):
@@ -31,10 +29,6 @@ def set_region_rules(world: "SohWorld") -> None:
          bundle) and can_use(Items.SONG_OF_STORMS, bundle) and (has_explosives(bundle) or has_item(Items.GORONS_BRACELET, bundle))),
         (EventLocations.DMT_BEAN_PATCH, LocalEvents.DMT_BEAN_PLANTED, lambda bundle: is_child(bundle) and can_use(
             Items.MAGIC_BEAN, bundle) and (has_explosives(bundle) or has_item(Items.GORONS_BRACELET, bundle))),
-        (EventLocations.DMT_DAY_NIGHT_CYCLE_CHILD,
-         Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
-        (EventLocations.DMT_DAY_NIGHT_CYCLE_ADULT,
-         Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle)),
     ])
     # Locations
     add_locations(Regions.DEATH_MOUNTAIN_TRAIL, world, [

--- a/worlds/oot_soh/location_access/overworld/desert_colossus.py
+++ b/worlds/oot_soh/location_access/overworld/desert_colossus.py
@@ -9,8 +9,6 @@ class EventLocations(StrEnum):
     DESERT_COLOSSUS_FAIRY_POND_OASIS = "Desert Colossus Fairy Pond Oasis"
     DESERT_COLOSSUS_BUG_ROCK = "Desert Colossus Bug Rock"
     DESERT_COLOSSUS_BEAN_PATCH = "Desert Colossus Bean Patch"
-    DESERT_COLOSSUS_DAY_NIGHT_CYCLE_CHILD = "Desert Colossus Day Night Cycle Child"
-    DESERT_COLOSSUS_DAY_NIGHT_CYCLE_ADULT = "Desert Colossus Day Night Cycle Adult"
 
 
 class LocalEvents(StrEnum):
@@ -27,10 +25,6 @@ def set_region_rules(world: "SohWorld") -> None:
          Events.CAN_ACCESS_BUGS, lambda bundle: True),
         (EventLocations.DESERT_COLOSSUS_BEAN_PATCH, LocalEvents.DESERT_COLOSSUS_BEAN_PLANTED,
          lambda bundle: is_child(bundle) and can_use(Items.MAGIC_BEAN, bundle)),
-        (EventLocations.DESERT_COLOSSUS_DAY_NIGHT_CYCLE_CHILD,
-         Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
-        (EventLocations.DESERT_COLOSSUS_DAY_NIGHT_CYCLE_ADULT,
-         Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle)),
     ])
     # Locations
     add_locations(Regions.DESERT_COLOSSUS, world, [

--- a/worlds/oot_soh/location_access/overworld/gerudo_valley.py
+++ b/worlds/oot_soh/location_access/overworld/gerudo_valley.py
@@ -9,8 +9,6 @@ class EventLocations(StrEnum):
     GV_GOSSIP_STONE_SONG_FAIRY = "GV Gossip Stone Song Fairy"
     GV_BEAN_SOIL = "GV Bean Soil"
     GV_BEAN_PATCH = "GV Bean Patch"
-    GV_DAY_NIGHT_CYCLE_CHILD = "GV Day Night Cycle Child"
-    GV_DAY_NIGHT_CYCLE_ADULT = "GV Day Night Cycle Adult"
 
 
 class LocalEvents(StrEnum):
@@ -23,10 +21,6 @@ def set_region_rules(world: "SohWorld") -> None:
     add_events(Regions.GERUDO_VALLEY, world, [
         (EventLocations.GV_BUG_ROCK, Events.CAN_ACCESS_BUGS,
          lambda bundle: is_child(bundle)),
-        (EventLocations.GV_DAY_NIGHT_CYCLE_CHILD,
-         Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
-        (EventLocations.GV_DAY_NIGHT_CYCLE_ADULT,
-         Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle)),
     ])
     # Locations
     add_locations(Regions.GERUDO_VALLEY, world, [

--- a/worlds/oot_soh/location_access/overworld/hyrule_field.py
+++ b/worlds/oot_soh/location_access/overworld/hyrule_field.py
@@ -22,8 +22,6 @@ class EventLocations(StrEnum):
     HF_NEAR_MARKET_GROTTO_BUTTERFLY_FAIRY = "HF Near Market Grotto Butterfly Fairy"
     HF_NEAR_MARKET_GROTTO_BUG_GRASS = "HF Near Market Grotto Bugs"
     HF_NEAR_MARKET_GROTTO_PUDDLE_FISH = "HF Near Market Grotto Puddle Fish"
-    HF_DAY_NIGHT_CYCLE_CHILD = "HF Day Night Cycle Child"
-    HF_DAY_NIGHT_CYCLE_ADULT = "HF Day Night Cycle Adult"
 
 
 def set_region_rules(world: "SohWorld") -> None:
@@ -39,10 +37,6 @@ def set_region_rules(world: "SohWorld") -> None:
                                                                                 has_item(Items.GORONS_RUBY, bundle) and
                                                                                 has_item(Items.ZORAS_SAPPHIRE, bundle) and
                                                                                 has_item(Items.CHILD_WALLET, bundle))),
-        (EventLocations.HF_DAY_NIGHT_CYCLE_CHILD,
-         Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
-        (EventLocations.HF_DAY_NIGHT_CYCLE_ADULT,
-         Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle)),
     ])
     # Locations
     add_locations(Regions.HYRULE_FIELD, world, [

--- a/worlds/oot_soh/location_access/overworld/lake_hylia.py
+++ b/worlds/oot_soh/location_access/overworld/lake_hylia.py
@@ -12,8 +12,6 @@ class EventLocations(StrEnum):
     CHILD_SCARECROW = "Child Scarecrow"
     ADULT_SCARECROW = "Adult Scarecrow"
     LH_BEAN_PATCH = "LH Bean Patch"
-    LH_DAY_NIGHT_CYCLE_CHILD = "LH Day Night Cycle Child"
-    LH_DAY_NIGHT_CYCLE_ADULT = "LH Day Night Cycle Adult"
 
 
 class LocalEvents(StrEnum):
@@ -41,10 +39,6 @@ def set_region_rules(world: "SohWorld") -> None:
          ocarina_button_count(bundle) >= 2),
         (EventLocations.LH_BEAN_PATCH, LocalEvents.LH_BEAN_PLANTED, lambda bundle: is_child(bundle) and
          can_use(Items.MAGIC_BEAN, bundle)),
-        (EventLocations.LH_DAY_NIGHT_CYCLE_CHILD,
-         Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
-        (EventLocations.LH_DAY_NIGHT_CYCLE_ADULT,
-         Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle)),
     ])
     # Locations
     add_locations(Regions.LAKE_HYLIA, world, [

--- a/worlds/oot_soh/location_access/overworld/zoras_river.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_river.py
@@ -12,8 +12,6 @@ class EventLocations(StrEnum):
     ZR_OPEN_GROTTO_BUG_GRASS = "ZR Upper Grotto Bug Grass"
     ZR_OPEN_GROTTO_POND_FISH = "ZR Upper Grotto Pond Fish"
     ZR_BEAN_PATCH = "ZR Bean Patch"
-    ZR_DAY_NIGHT_CYCLE_CHILD = "ZR Day Night Cycle Child"
-    ZR_DAY_NIGHT_CYCLE_ADULT = "ZR Day Night Cycle Adult"
 
 
 class LocalEvents(StrEnum):
@@ -22,13 +20,6 @@ class LocalEvents(StrEnum):
 
 def set_region_rules(world: "SohWorld") -> None:
     # ZR Front
-    # Events
-    add_events(Regions.ZR_FRONT, world, [
-        (EventLocations.ZR_DAY_NIGHT_CYCLE_CHILD,
-         Events.CHILD_CAN_PASS_TIME, lambda bundle: is_child(bundle)),
-        (EventLocations.ZR_DAY_NIGHT_CYCLE_ADULT,
-         Events.ADULT_CAN_PASS_TIME, lambda bundle: is_adult(bundle)),
-    ])
     # Locations
     add_locations(Regions.ZR_FRONT, world, [
         (Locations.ZR_GS_TREE, lambda bundle: is_child(bundle) and can_bonk_trees(bundle) and


### PR DESCRIPTION
This takes what console OOT uses and adapts it to Ship's current logic. Console OOT only uses this when specific entrances are randomized likely because of how heavy this is.

I as a fallback, it still uses the event's we have when the complexity isn't needed. I also created more of these events.

I'm not saying this is the perfect solution, because currently there are times when a single world generation can take longer than 60 seconds to complete. I'm putting this here to broach the topic of day/night and seeing if we can either adapt this and make it better or come up with a better solution.