### PR TITLE
Fix extra heart container in the pool

### DIFF
--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -517,7 +517,7 @@ def create_item_pool(world: "SohWorld") -> None:
             items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(
                 world, Items.PIECE_OF_HEART, ItemClassification.useful | ItemClassification.skip_balancing, non_progression_piece_amount - 1)
             items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(
-                world, Items.HEART_CONTAINER, ItemClassification.useful | ItemClassification.skip_balancing, 1)
+                world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful | ItemClassification.skip_balancing, 1)
         
 
     # if Greg isn't necessary to win, make him filler
@@ -553,6 +553,9 @@ def create_item_pool(world: "SohWorld") -> None:
 
 
 def create_special_progression_item(world: "SohWorld", item: Items, classification: ItemClassification, amount: int = 1) -> int:
+    if amount < 1:
+        return 0
+
     items = [world.create_item(item, classification=classification)
              for _ in range(amount)]
 

--- a/worlds/oot_soh/test/test_hearts.py
+++ b/worlds/oot_soh/test/test_hearts.py
@@ -31,3 +31,7 @@ class TestHearts(SohTestBase):
 
         self.remove(heart)
         self.assertTrue(self.multiworld.state.soh_heart_count[self.player] == 4)  # type: ignore
+
+    def test_collecting_all_hearts_count(self):
+        self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER ])
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 20, "after collecting all heart pieces and containers we should have 20 hearts") # type: ignore 


### PR DESCRIPTION
Fixing the issue which replaces a winner piece of heart with a full heart container in the item pool.
This block of code may still be broken which might cause us to create a winner piece of heart as a "usefull" "skip balancing" item for no reason.