### PR TITLE
Rework heart useful calculation

### DIFF
--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -508,20 +508,29 @@ def create_item_pool(world: "SohWorld") -> None:
         else:
              # starting health is less than min_hearts_needed
             # Get the total number of heart classifications we have to work with
-            total_non_progression_hearts: int = max_hearts - min_hearts_needed # 9
+            total_non_progression_hearts: int = max_hearts - min_hearts_needed
 
-            # Heart Piece amount to make useful.
-            non_progression_piece_amount: int = int((items_to_create[Items.PIECE_OF_HEART] + items_to_create[Items.PIECE_OF_HEART_WINNER]) / 4) # 9
+            # Heart Piece amount to make useful. Convert to actual hearts, then convert back later
+            non_progression_piece_amount: int = int((items_to_create[Items.PIECE_OF_HEART] + items_to_create[Items.PIECE_OF_HEART_WINNER]) / 4)
             
             if total_non_progression_hearts >= non_progression_piece_amount: 
                 items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
                 items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
 
-                total_non_progression_hearts -= non_progression_piece_amount # 17 - 9 = 8
+                total_non_progression_hearts -= non_progression_piece_amount
+            elif world.options.item_pool not in ("plentiful", "minimal"):
+                non_progression_piece_amount = total_non_progression_hearts
+                
+                items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
+                items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
+
+                total_non_progression_hearts = 0
 
             # Container amount to make useful
             if total_non_progression_hearts >= items_to_create[Items.HEART_CONTAINER]:
-                items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, items_to_create[Items.HEART_CONTAINER])        
+                items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, items_to_create[Items.HEART_CONTAINER])
+            else:
+                items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, total_non_progression_hearts)
 
     # if Greg isn't necessary to win, make him filler
     if not (world.options.rainbow_bridge == "greg" or (world.options.rainbow_bridge and world.options.rainbow_bridge_greg_modifier) or (world.options.ganons_castle_boss_key and world.options.ganons_castle_boss_key_greg_modifier)):

--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -506,28 +506,22 @@ def create_item_pool(world: "SohWorld") -> None:
             items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, items_to_create[Items.PIECE_OF_HEART_WINNER])
             items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, items_to_create[Items.HEART_CONTAINER])
         else:
-            # starting health is less than min_hearts_needed
-            # Get the total number of hearts that don't need to be progression
-            total_non_progression_hearts: int = min_hearts_needed - world.multiworld.state.soh_heart_count[world.player] 
+             # starting health is less than min_hearts_needed
+            # Get the total number of heart classifications we have to work with
+            total_non_progression_hearts: int = max_hearts - min_hearts_needed # 9
+
+            # Heart Piece amount to make useful.
+            non_progression_piece_amount: int = int((items_to_create[Items.PIECE_OF_HEART] + items_to_create[Items.PIECE_OF_HEART_WINNER]) / 4) # 9
+            
+            if total_non_progression_hearts >= non_progression_piece_amount: 
+                items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
+                items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
+
+                total_non_progression_hearts -= non_progression_piece_amount # 17 - 9 = 8
+
             # Container amount to make useful
-            non_progression_container_amount: int = items_to_create[Items.HEART_CONTAINER]
-            # Heart Piece amount to make useful. Convert to regular heart here then convert back later for simplicity
-            non_progression_piece_amount: int = int((items_to_create[Items.PIECE_OF_HEART] + items_to_create[Items.PIECE_OF_HEART_WINNER]) / 4)
-            # Calcuate what needs to be useful. Try Heart Pieces first. This is because we would prefer the contains to be progression because there are less of them always
-            if total_non_progression_hearts < non_progression_piece_amount:
-                temp_non_progression_hearts = non_progression_piece_amount - total_non_progression_hearts
-                if world.options.item_pool == "minimal":
-                    non_progression_piece_amount = 0
-                elif world.options.item_pool == "scarce":
-                    non_progression_piece_amount = min(non_progression_piece_amount , temp_non_progression_hearts) if world.options.item_pool != "minimal" or non_progression_container_amount > 0 else 0
-
-                if non_progression_piece_amount > 0:
-                    items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
-                    items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
-
-                # Try to convert the containers second
-                if total_non_progression_hearts <= non_progression_container_amount:
-                    items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, non_progression_container_amount - total_non_progression_hearts)        
+            if total_non_progression_hearts >= items_to_create[Items.HEART_CONTAINER]:
+                items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, items_to_create[Items.HEART_CONTAINER])        
 
     # if Greg isn't necessary to win, make him filler
     if not (world.options.rainbow_bridge == "greg" or (world.options.rainbow_bridge and world.options.rainbow_bridge_greg_modifier) or (world.options.ganons_castle_boss_key and world.options.ganons_castle_boss_key_greg_modifier)):
@@ -562,6 +556,9 @@ def create_item_pool(world: "SohWorld") -> None:
 
 
 def create_special_progression_item(world: "SohWorld", item: Items, classification: ItemClassification, amount: int = 1) -> int:
+    if amount < 1:
+        return 0
+
     items = [world.create_item(item, classification=classification)
              for _ in range(amount)]
 

--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -510,27 +510,28 @@ def create_item_pool(world: "SohWorld") -> None:
             # Get the total number of heart classifications we have to work with
             total_non_progression_hearts: int = max_hearts - min_hearts_needed
 
-            # Heart Piece amount to make useful. Convert to actual hearts, then convert back later
-            non_progression_piece_amount: int = int((items_to_create[Items.PIECE_OF_HEART] + items_to_create[Items.PIECE_OF_HEART_WINNER]) / 4)
+            if total_non_progression_hearts > 0:
+                # Heart Piece amount to make useful. Convert to actual hearts, then convert back later
+                non_progression_piece_amount: int = int((items_to_create[Items.PIECE_OF_HEART] + items_to_create[Items.PIECE_OF_HEART_WINNER]) / 4)
             
-            if total_non_progression_hearts >= non_progression_piece_amount: 
-                items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
-                items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
+                if total_non_progression_hearts >= non_progression_piece_amount: 
+                    items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
+                    items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
 
-                total_non_progression_hearts -= non_progression_piece_amount
-            elif world.options.item_pool not in ("plentiful", "minimal"):
-                non_progression_piece_amount = total_non_progression_hearts
-                
-                items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
-                items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
+                    total_non_progression_hearts -= non_progression_piece_amount
+                elif world.options.item_pool not in ("plentiful", "minimal"):
+                    non_progression_piece_amount = total_non_progression_hearts
+                    
+                    items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
+                    items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
 
-                total_non_progression_hearts = 0
+                    total_non_progression_hearts = 0
 
-            # Container amount to make useful
-            if total_non_progression_hearts >= items_to_create[Items.HEART_CONTAINER]:
-                items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, items_to_create[Items.HEART_CONTAINER])
-            else:
-                items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, total_non_progression_hearts)
+                # Container amount to make useful
+                if total_non_progression_hearts >= items_to_create[Items.HEART_CONTAINER]:
+                    items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, items_to_create[Items.HEART_CONTAINER])
+                else:
+                    items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, total_non_progression_hearts)
 
     # if Greg isn't necessary to win, make him filler
     if not (world.options.rainbow_bridge == "greg" or (world.options.rainbow_bridge and world.options.rainbow_bridge_greg_modifier) or (world.options.ganons_castle_boss_key and world.options.ganons_castle_boss_key_greg_modifier)):

--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -498,27 +498,36 @@ def create_item_pool(world: "SohWorld") -> None:
         items_to_create[Items.GOLD_SKULLTULA_TOKEN] -= create_special_progression_item(
             world, Items.GOLD_SKULLTULA_TOKEN, ItemClassification.useful | ItemClassification.deprioritized | ItemClassification.skip_balancing, items_to_create[Items.GOLD_SKULLTULA_TOKEN] - world.randomized_progressive_skulltula_count)
 
-    # If hearts aren't logically relevent (or you have enough to do everything) make them useful
-    min_hearts_needed: int = 3
-    if not (world.options.enable_all_tricks or str(Tricks.FEWER_TUNIC_REQUIREMENTS) in world.options.tricks_in_logic.value or world.multiworld.state.soh_heart_count[world.player] < min_hearts_needed):
-        progression_hearts: int = min_hearts_needed - world.multiworld.state.soh_heart_count[world.player]
-        non_progression_container_amount: int = 0
-        non_progression_piece_amount: int = 0
-        if progression_hearts > 0 and items_to_create[Items.HEART_CONTAINER] > 0:
-            non_progression_container_amount = items_to_create[Items.HEART_CONTAINER] - progression_hearts
+    # If you start with enough hearts to do everything and tricks aren't enabled make the rest of them useful
+    if not (world.options.enable_all_tricks or str(Tricks.FEWER_TUNIC_REQUIREMENTS) in world.options.tricks_in_logic.value):
+        min_hearts_needed: int = 3
+        if world.multiworld.state.soh_heart_count[world.player] >= min_hearts_needed:
+            items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, items_to_create[Items.PIECE_OF_HEART])
+            items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, items_to_create[Items.PIECE_OF_HEART_WINNER])
+            items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, items_to_create[Items.HEART_CONTAINER])
+        else:
+            # starting health is less than min_hearts_needed
+            # Get the total number of hearts that don't need to be progression
+            total_non_progression_hearts: int = min_hearts_needed - world.multiworld.state.soh_heart_count[world.player] 
+            # Container amount to make useful
+            non_progression_container_amount: int = items_to_create[Items.HEART_CONTAINER]
+            # Heart Piece amount to make useful. Convert to regular heart here then convert back later for simplicity
+            non_progression_piece_amount: int = int((items_to_create[Items.PIECE_OF_HEART] + items_to_create[Items.PIECE_OF_HEART_WINNER]) / 4)
+            # Calcuate what needs to be useful. Try Heart Pieces first. This is because we would prefer the contains to be progression because there are less of them always
+            if total_non_progression_hearts < non_progression_piece_amount:
+                temp_non_progression_hearts = non_progression_piece_amount - total_non_progression_hearts
+                if world.options.item_pool == "minimal":
+                    non_progression_piece_amount = 0
+                elif world.options.item_pool == "scarce":
+                    non_progression_piece_amount = min(non_progression_piece_amount , temp_non_progression_hearts) if world.options.item_pool != "minimal" or non_progression_container_amount > 0 else 0
 
-        if non_progression_container_amount == 0:
-            non_progression_container_amount = progression_hearts * 4
+                if non_progression_piece_amount > 0:
+                    items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(world, Items.PIECE_OF_HEART, ItemClassification.useful, ((non_progression_piece_amount * 4) - 1))
+                    items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(world, Items.PIECE_OF_HEART_WINNER, ItemClassification.useful, 1)
 
-        items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(
-            world, Items.HEART_CONTAINER, ItemClassification.useful | ItemClassification.skip_balancing, non_progression_container_amount)
-        
-        if world.options.item_pool != "minimal":
-            items_to_create[Items.PIECE_OF_HEART] -= create_special_progression_item(
-                world, Items.PIECE_OF_HEART, ItemClassification.useful | ItemClassification.skip_balancing, non_progression_piece_amount - 1)
-            items_to_create[Items.PIECE_OF_HEART_WINNER] -= create_special_progression_item(
-                world, Items.HEART_CONTAINER, ItemClassification.useful | ItemClassification.skip_balancing, 1)
-        
+                # Try to convert the containers second
+                if total_non_progression_hearts <= non_progression_container_amount:
+                    items_to_create[Items.HEART_CONTAINER] -= create_special_progression_item(world, Items.HEART_CONTAINER, ItemClassification.useful, non_progression_container_amount - total_non_progression_hearts)        
 
     # if Greg isn't necessary to win, make him filler
     if not (world.options.rainbow_bridge == "greg" or (world.options.rainbow_bridge and world.options.rainbow_bridge_greg_modifier) or (world.options.ganons_castle_boss_key and world.options.ganons_castle_boss_key_greg_modifier)):

--- a/worlds/oot_soh/test/test_hearts.py
+++ b/worlds/oot_soh/test/test_hearts.py
@@ -33,6 +33,11 @@ class TestHearts(SohTestBase):
         self.remove(heart)
         self.assertTrue(self.multiworld.state.soh_heart_count[self.player] == 4)  # type: ignore
 
+    def test_collecting_all_hearts_count(self):
+        self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER ])
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 20, "after collecting all heart pieces and containers we should have 20 hearts") # type: ignore 
+
+
 class TestHeartsMinimal(SohTestBase):
     options = {"starting_hearts": 1, "item_pool": "minimal"}
     def test_collecting_all_hearts_count(self):

--- a/worlds/oot_soh/test/test_hearts.py
+++ b/worlds/oot_soh/test/test_hearts.py
@@ -33,10 +33,42 @@ class TestHearts(SohTestBase):
         self.remove(heart)
         self.assertTrue(self.multiworld.state.soh_heart_count[self.player] == 4)  # type: ignore
 
+class TestHeartsBalanced(SohTestBase):
+    options = {"starting_hearts": 1, "item_pool": "balanced"}
     def test_collecting_all_hearts_count(self):
-        self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER ])
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 1, "start with 1 heart") # type: ignore 
+        self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER])
         self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 20, "after collecting all heart pieces and containers we should have 20 hearts") # type: ignore 
 
+    def test_count_hearts_progression(self):
+        poh = list()
+        winner = list()
+        container = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART and (item.classification & IC.progression) == IC.progression:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER and (item.classification & IC.progression) == IC.progression:
+                winner.append(item)    
+            if item.name == Items.HEART_CONTAINER and (item.classification & IC.progression) == IC.progression:
+                container.append(item)    
+        self.assertEqual(len(poh), 0, "Should have been 0 PoH")
+        self.assertEqual(len(winner), 0, "Should have been 0 Winner PoH")
+        self.assertEqual(len(container), 2, "Should have been 2 Containers")
+
+    def test_count_heart_total(self):
+        poh = list()
+        winner = list()
+        container = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER:
+                winner.append(item)    
+            if item.name == Items.HEART_CONTAINER:
+                container.append(item)   
+        self.assertEqual(len(poh), 39, "Should have been 39 PoH")
+        self.assertEqual(len(winner), 1, "Should have been 1 Winner PoH")
+        self.assertEqual(len(container), 9, "Should have been 9 Containers")
 
 class TestHeartsMinimal(SohTestBase):
     options = {"starting_hearts": 1, "item_pool": "minimal"}
@@ -45,16 +77,21 @@ class TestHeartsMinimal(SohTestBase):
         self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER])
         self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 3, "after collecting all heart pieces and containers we should have 3 hearts") # type: ignore 
 
-    def test_count_heart_pieces_progression(self):
+    def test_count_hearts_progression(self):
         poh = list()
         winner = list()
+        container = list()
         for item in self.multiworld.itempool:
             if item.name == Items.PIECE_OF_HEART and (item.classification & IC.progression) == IC.progression:
                 poh.append(item)
             if item.name == Items.PIECE_OF_HEART_WINNER and (item.classification & IC.progression) == IC.progression:
-                winner.append(item)    
+                winner.append(item)
+            if item.name == Items.HEART_CONTAINER and (item.classification & IC.progression) == IC.progression:
+                container.append(item)    
         self.assertEqual(len(poh), 3, "Should have been 3 PoH")
         self.assertEqual(len(winner), 1, "Should have been 1 Winner PoH")
+        self.assertEqual(len(container), 0, "Should have been 0 Containers")
+
 
     def test_count_heart_total(self):
         poh = list()
@@ -78,16 +115,20 @@ class TestHeartsScarce(SohTestBase):
         self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER])
         self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 12, "after collecting all heart pieces and containers we should have 12 hearts") # type: ignore 
 
-    def test_count_heart_pieces_progression(self):
+    def test_count_hearts_progression(self):
         poh = list()
         winner = list()
+        container = list()
         for item in self.multiworld.itempool:
             if item.name == Items.PIECE_OF_HEART and (item.classification & IC.progression) == IC.progression:
                 poh.append(item)
             if item.name == Items.PIECE_OF_HEART_WINNER and (item.classification & IC.progression) == IC.progression:
                 winner.append(item)    
+            if item.name == Items.HEART_CONTAINER and (item.classification & IC.progression) == IC.progression:
+                container.append(item)   
         self.assertEqual(len(poh), 8, "Should have been 8 PoH")
         self.assertEqual(len(winner), 0, "Should have been 0 Winner PoH")
+        self.assertEqual(len(container), 0, "Should have been 0 Containers")
 
     def test_count_heart_total(self):
         poh = list()
@@ -103,3 +144,40 @@ class TestHeartsScarce(SohTestBase):
         self.assertEqual(len(container), 0, "Should have been 0 Containers")
         self.assertEqual(len(poh), 43, "Should have been 43 PoH")
         self.assertEqual(len(winner), 1, "Should have been 1 Winner PoH")
+
+class TestHeartsPlentiful(SohTestBase):
+    options = {"starting_hearts": 1, "item_pool": "plentiful"}
+    def test_collecting_all_hearts_count(self):
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 1, "start with 1 heart") # type: ignore 
+        self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER])
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 20, "after collecting all heart pieces and containers we should have 20 hearts") # type: ignore 
+
+    def test_count_hearts_progression(self):
+        poh = list()
+        winner = list()
+        container = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART and (item.classification & IC.progression) == IC.progression:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER and (item.classification & IC.progression) == IC.progression:
+                winner.append(item)    
+            if item.name == Items.HEART_CONTAINER and (item.classification & IC.progression) == IC.progression:
+                container.append(item)    
+        self.assertEqual(len(poh), 0, "Should have been 0 PoH")
+        self.assertEqual(len(winner), 0, "Should have been 0 Winner PoH")
+        self.assertEqual(len(container), 2, "Should have been 2 Containers")
+
+    def test_count_heart_total(self):
+        poh = list()
+        winner = list()
+        container = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER:
+                winner.append(item)    
+            if item.name == Items.HEART_CONTAINER:
+                container.append(item)   
+        self.assertEqual(len(poh), 3, "Should have been 3 PoH")
+        self.assertEqual(len(winner), 1, "Should have been 1 Winner PoH")
+        self.assertEqual(len(container), 18, "Should have been 18 Containers")

--- a/worlds/oot_soh/test/test_hearts.py
+++ b/worlds/oot_soh/test/test_hearts.py
@@ -1,6 +1,7 @@
 from .. import SohWorld
 from ..Items import Items
 from .bases import SohTestBase
+from BaseClasses import ItemClassification as IC
 
 
 class TestHearts(SohTestBase):
@@ -31,3 +32,69 @@ class TestHearts(SohTestBase):
 
         self.remove(heart)
         self.assertTrue(self.multiworld.state.soh_heart_count[self.player] == 4)  # type: ignore
+
+class TestHeartsMinimal(SohTestBase):
+    options = {"starting_hearts": 1, "item_pool": "minimal"}
+    def test_collecting_all_hearts_count(self):
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 1, "start with 1 heart") # type: ignore 
+        self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER])
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 3, "after collecting all heart pieces and containers we should have 3 hearts") # type: ignore 
+
+    def test_count_heart_pieces_progression(self):
+        poh = list()
+        winner = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART and (item.classification & IC.progression) == IC.progression:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER and (item.classification & IC.progression) == IC.progression:
+                winner.append(item)    
+        self.assertEqual(len(poh), 3, "Should have been 3 PoH")
+        self.assertEqual(len(winner), 1, "Should have been 1 Winner PoH")
+
+    def test_count_heart_total(self):
+        poh = list()
+        winner = list()
+        container = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER:
+                winner.append(item)    
+            if item.name == Items.HEART_CONTAINER:
+                container.append(item)   
+        self.assertEqual(len(container), 1, "Should have been 0 Containers")
+        self.assertEqual(len(poh), 3, "Should have been 3 PoH")
+        self.assertEqual(len(winner), 1, "Should have been 1 Winner PoH")
+
+class TestHeartsScarce(SohTestBase):
+    options = {"starting_hearts": 1, "item_pool": "scarce"}
+    def test_collecting_all_hearts_count(self):
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 1, "start with 1 heart") # type: ignore 
+        self.collect_by_name([Items.PIECE_OF_HEART, Items.PIECE_OF_HEART_WINNER, Items.HEART_CONTAINER])
+        self.assertEqual(self.multiworld.state.soh_heart_count[self.player], 12, "after collecting all heart pieces and containers we should have 12 hearts") # type: ignore 
+
+    def test_count_heart_pieces_progression(self):
+        poh = list()
+        winner = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART and (item.classification & IC.progression) == IC.progression:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER and (item.classification & IC.progression) == IC.progression:
+                winner.append(item)    
+        self.assertEqual(len(poh), 8, "Should have been 8 PoH")
+        self.assertEqual(len(winner), 0, "Should have been 0 Winner PoH")
+
+    def test_count_heart_total(self):
+        poh = list()
+        winner = list()
+        container = list()
+        for item in self.multiworld.itempool:
+            if item.name == Items.PIECE_OF_HEART:
+                poh.append(item)
+            if item.name == Items.PIECE_OF_HEART_WINNER:
+                winner.append(item)    
+            if item.name == Items.HEART_CONTAINER:
+                container.append(item)   
+        self.assertEqual(len(container), 0, "Should have been 0 Containers")
+        self.assertEqual(len(poh), 43, "Should have been 43 PoH")
+        self.assertEqual(len(winner), 1, "Should have been 1 Winner PoH")


### PR DESCRIPTION
If relevant tricks are disabled, and you have more hearts than the minimum require to get everywhere, just make all the hearts useful.

If the player has less starting hearts than required, calculate how many pieces and containers should be converted to useful. Had to do some shenanigans to make it work with all the item pool options. In my testing (starting 1 and 2 hearts and all the item pool options) it seemed to work out. 

Would be good to have someone double check my math as I clearly need it from the state of this before.