### PR TITLE
Swap which coffin in the bottom of the well is open by default

### DIFF
--- a/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
+++ b/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
@@ -165,9 +165,9 @@ def set_region_rules(world: "SohWorld") -> None:
     add_locations(Regions.BOTTOM_OF_THE_WELL_COFFIN_ROOM, world, [
         (Locations.BOTTOM_OF_THE_WELL_FREESTANDING_KEY, lambda bundle: has_fire_source_with_torch(
             bundle) | can_use(Items.FAIRY_BOW, bundle)),
-        (Locations.BOTTOM_OF_THE_WELL_COFFIN_ROOM_FRONT_LEFT_HEART, lambda bundle: True_()),
-        (Locations.BOTTOM_OF_THE_WELL_COFFIN_ROOM_MIDDLE_RIGHT_HEART,
-         lambda bundle: has_fire_source_with_torch(bundle) | can_use(Items.FAIRY_BOW, bundle))
+        (Locations.BOTTOM_OF_THE_WELL_COFFIN_ROOM_FRONT_LEFT_HEART, 
+            lambda bundle: has_fire_source_with_torch(bundle) | can_use(Items.FAIRY_BOW, bundle)),
+        (Locations.BOTTOM_OF_THE_WELL_COFFIN_ROOM_MIDDLE_RIGHT_HEART, lambda bundle: True_())
 
     ])
     # Connections


### PR DESCRIPTION
The coffin that's open by default in the bottom of the well is incorrect.

This is also an issue upstream, @Brian0255 is PRing the [upstream fix](https://github.com/HarbourMasters/Shipwright/pull/6743).
It would be nice to include this into next release as well

<img width="1903" height="1065" alt="image" src="https://github.com/user-attachments/assets/2728ea7f-9431-4a2f-88b0-df6f835c4805" />
