### PR TITLE
Removed assert

### DIFF
--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -269,8 +269,6 @@ class CanAffordSlot(Rule, game="Ship of Harkinian"):
 
 
 def get_wallet_for_shop_slot(location: Locations, world: "SohWorld") -> tuple[str, int]:
-    assert location in world.shop_prices, f'Shop location "{str(location)}" does not have a price assigned'
-
     price = world.shop_prices.get(location, 500)
     for wallet, amount in wallet_capacities.items():
         if amount >= price:


### PR DESCRIPTION
Prevented generation in some scenarios where the multiworld was swept before prices were set. 

It will default to the max of Giant Wallet if the price hasn't been set beforehand.

I think this makes sense instead of filling with locations/prices before. Accomplishes the same thing with less code.