### PR TITLE
Fix broken exit on SFM_WOLFOS_GROTTO region

### DIFF
--- a/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
+++ b/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
@@ -84,7 +84,7 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.SFM_WOLFOS_GROTTO, world, [
-        (Regions.SACRED_FOREST_MEADOW, lambda bundle: True_()),
+        (Regions.SFM_ENTRYWAY, lambda bundle: True_()),
     ])
 
     # SFM Storms Grotto


### PR DESCRIPTION
This region was mistakenly connecting to SACRED_FOREST_MEADOW which is the region beyond the Wolfos gate, which is not correct. This fixes it and is also what upstream shows for the exit connection: https://github.com/HarbourMasters/Shipwright/blob/0d2346d322b00df45470338406ef290d210ac92e/soh/soh/Enhancements/randomizer/location_access/overworld/sacred_forest_meadow.cpp#L85