### PR TITLE
Clear hint description clarification

### DIFF
--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -1114,6 +1114,8 @@ class HintClarity(Choice):
     (Quality of groups depends on game)
 
     Clear - Hints tell you exactly what the item is and opens the hint in the hint tab for free.
+    Hints will not be automatically opened for Gossip Stones as not all Gossip Stone hints point
+    to a location directly.
     Boomerang > Boomerang
     """
     display_name = "Hint Clarity"


### PR DESCRIPTION
We may want to look into opening hints for gossip stones anyway, but we'd have to scour the hint key for every gossip stone and check if it is assigned to only one location or something along those lines. Not very simple to do, so let's atleast clarify in the description until then.