### PR TITLE
Fix LH_LAB_DIVE trick not requiring Hookshot

### DIFF
--- a/worlds/oot_soh/location_access/overworld/lake_hylia.py
+++ b/worlds/oot_soh/location_access/overworld/lake_hylia.py
@@ -217,6 +217,7 @@ def set_region_rules(world: "SohWorld") -> None:
         (Locations.LH_LAB_DIVE, lambda bundle: has_item(Items.GOLDEN_SCALE, bundle) |
          (can_do_trick(Tricks.LH_LAB_DIVING, bundle) &
           can_use(Items.IRON_BOOTS, bundle) &
+          can_use(Items.HOOKSHOT, bundle) &
           has_item(Items.BRONZE_SCALE, bundle))),
         (Locations.LH_LAB_TRADE_EYEBALL_FROG, lambda bundle: is_adult(bundle) &
          can_use(Items.EYEBALL_FROG, bundle)),


### PR DESCRIPTION
The Lake Hylia lab diving trick was incorrectly not requiring Hookshot to do it, this PR fixes that

It looks like upstream Ship has had a refactor of sorts for Lake Hylia, but I believe this small fix should match intent?
https://github.com/HarbourMasters/Shipwright/blob/c5835669fec5c804156943b5cd6e8da3a1bd6489/soh/soh/Enhancements/randomizer/location_access/overworld/lake_hylia.cpp#L124-L150
