### PR TITLE
DMT GS Near Kak Logic fix

### DIFF
--- a/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
@@ -44,7 +44,7 @@ def set_region_rules(world: "SohWorld") -> None:
          & has_item(LocalEvents.DMT_BEAN_PLANTED, bundle) & (has_explosives(bundle) | has_item(Items.GORONS_BRACELET, bundle)))),
         (Locations.DMT_GS_BEAN_PATCH, lambda bundle: can_spawn_soil_skull(bundle) & (has_explosives(bundle) | has_item(Items.GORONS_BRACELET, bundle) | (
             can_do_trick(Tricks.DMT_SOIL_GS, bundle) & (take_damage(bundle) | can_use(Items.HOVER_BOOTS, bundle)) & can_use(Items.BOOMERANG, bundle)))),
-        (Locations.DMT_GS_NEAR_KAK, lambda bundle: blast_or_smash(bundle)),
+        (Locations.DMT_GS_NEAR_KAK, lambda bundle: blast_or_smash(bundle) & has_projectile(bundle)),
         (Locations.DMT_GS_ABOVE_DODONGOS_CAVERN, lambda bundle: is_adult(bundle) & at_night(bundle) & (can_use(Items.MEGATON_HAMMER, bundle) | (can_do_trick(Tricks.DMT_HOOKSHOT_LOWER_GS, bundle) & can_use(Items.HOOKSHOT, bundle)) | (can_do_trick(
             Tricks.DMT_BEAN_LOWER_GS, bundle) & has_item(LocalEvents.DMT_BEAN_PLANTED, bundle)) | (can_do_trick(Tricks.DMT_HOVERS_LOWER_GS, bundle) & can_use(Items.HOVER_BOOTS, bundle)) | can_do_trick(Tricks.DMT_JS_LOWER_GS, bundle)) & can_get_nighttime_gs(bundle)),
         (Locations.DMT_BLUE_RUPEE_UNDER_BOULDER,


### PR DESCRIPTION
The Skulltula near kak in DMT seems to only have logic for breaking the wall to access it, and not actually killing it

This is resulting in a case where hammer puts this GS in logic but hammer cannot kill this skulltula by itself as it is too high for crouch stabs

This also isn’t matching upstream logic for this GS: https://github.com/HarbourMasters/Shipwright/blob/dfaed908683893bfa8c9a043bd3d0cefa536ba28/soh/soh/Enhancements/randomizer/location_access/overworld/death_mountain_trail.cpp#L16

I have added "has_projectile" to this logic so bombs or a ranged weapon is required to kill the skulltula then climb the wall (or retrieve with hookshot/boomerang), however since there is no climb ability shuffle yet this cannot match upstream perfectly so this will need reviewed again when climb shuffle is added.

Thought about changing the blast_or_smash to has_explosives as hammer logic is redundant now but opted to try stay as close to upstream as possible