### PR TITLE
LLR Talon Chickens and Malon Minor Logic fix

### DIFF
--- a/worlds/oot_soh/location_access/overworld/lon_lon_ranch.py
+++ b/worlds/oot_soh/location_access/overworld/lon_lon_ranch.py
@@ -20,8 +20,7 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Locations
     add_locations(Regions.LON_LON_RANCH, world, [
-        (Locations.SONG_FROM_MALON, lambda bundle: is_child(bundle) & has_item(
-            Items.ZELDAS_LETTER, bundle) & has_item(Items.FAIRY_OCARINA, bundle) & at_day(bundle)),
+        (Locations.SONG_FROM_MALON, lambda bundle: is_child(bundle) & can_use(Items.WEIRD_EGG, bundle) & has_item(Items.FAIRY_OCARINA, bundle) & at_day(bundle)),
         (Locations.LLR_GS_TREE, lambda bundle: is_child(
             bundle) & can_bonk_trees(bundle)),
         (Locations.LLR_GS_RAIN_SHED, lambda bundle: is_child(
@@ -65,7 +64,7 @@ def set_region_rules(world: "SohWorld") -> None:
     # Locations
     add_locations(Regions.LLR_TALONS_HOUSE, world, [
         (Locations.LLR_TALONS_CHICKENS, lambda bundle: has_item(Items.CHILD_WALLET, bundle)
-         & is_child(bundle) & at_day(bundle) & has_item(Items.ZELDAS_LETTER, bundle)),
+         & is_child(bundle) & at_day(bundle) & can_use(Items.WEIRD_EGG, bundle)),
         (Locations.LLR_TALONS_HOUSE_POT1, lambda bundle: can_break_pots(bundle)),
         (Locations.LLR_TALONS_HOUSE_POT2, lambda bundle: can_break_pots(bundle)),
         (Locations.LLR_TALONS_HOUSE_POT3, lambda bundle: can_break_pots(bundle)),


### PR DESCRIPTION
Currently there is a minor logic bug with Talons Chickens and Song from Malon checks in LLR which puts them in logic if Zelda's letter is obtained, either through glitch's or from the enabled trick, however Zelda's Letter does not determine when these checks are accessible, Wield Egg (Waking Talon) does, thus this PR is for changing Zelda's Letter requirement to Wierd Egg instead (it might cause some small confusion for newer players if they see this on trackers but they can be directed to wake talon at the castle first)

This also now matches closer to upstream ship logic (minus the unimplemented things): https://github.com/HarbourMasters/Shipwright/blob/848106039d02d813f59a6a76b87d3ced233e0eb9/soh/soh/Enhancements/randomizer/location_access/overworld/lon_lon_ranch.cpp#L14 (and Line 41)

Since this is only a issue with skipping talon its a minor one however if someone enables the trick to skip waking talon to get zelda's letter that will put these 2 checks in logic which will result in them being inaccessible with weird egg shuffled.

The alternative to this is making an event for waking Talon depends what you guys are happy with.